### PR TITLE
Changed single quotes to doubles

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -28,7 +28,7 @@ class dns::server::config {
     ensure  => present,
     target  => '/etc/bind/named.conf.local',
     order   => 1,
-    content => '// File managed by Puppet.\n'
+    content => "// File managed by Puppet.\n"
   }
 
 }


### PR DESCRIPTION
Changed single quotes to doubles to allow for proper parsing of "\n"
