### PR TITLE
A few Modulefile corrections

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,4 +1,4 @@
-name 'puppet-dns'
+name 'ajjahn-puppet_dns'
 version '0.1.3'
 summary "Module for provisioning DNS (bind9)"
 description "Module for provisioning DNS (bind9)"


### PR DESCRIPTION
I was having difficulty installing this module and discovered a few errors in the Modulefile, specifically that the module name should include the username, and the dependency should include a slash (/) instead of a hyphen (-) to separate the user and project name.

http://docs.puppetlabs.com/puppet/2.7/reference/modules_publishing.html#a-note-on-module-names

> A Note on Module Names
> 
> Because many users have published their own versions of modules with common names (“mysql,” 
> “bacula,” etc.), the Puppet Forge requires module names to have a username prefix. That is, if a user > named “puppetlabs” maintained a “mysql” module, it would be known to the Puppet Forge as 
> puppetlabs-mysql.
> 
> Be sure to use this long name in your module’s Modulefile. However, you do not have to rename the 
> module’s directory, and can leave the module in your active modulepath — the build action will do 
> the right thing as long as the Modulefile is correct.

http://docs.puppetlabs.com/puppet/2.7/reference/modules_publishing.html#dependencies-in-the-modulefile

> Warning: The full name in a dependency must use a slash between the username and module name. > This is different from the name format used elsewhere in the Modulefile. This is a legacy architecture 
> problem with the Puppet Forge, and we apologize for the inconvenience. Our eventual plan is to allow > full names with hyphens everywhere while continuing to allow names with slashes, then (eventually, 
> much later) phase out names with slashes.
