### PR TITLE
Dependency version

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -5,4 +5,4 @@ description "Module for provisioning DNS (bind9)"
 author 'Adam Jahn'
 project_page 'https://github.com/ajjahn/puppet-dns'
 source 'https://github.com/ajjahn/puppet-dns'
-dependency 'ripienaar/concat', '0.1.0'
+dependency 'ripienaar/concat', '>=0.1.0'


### PR DESCRIPTION
One more minor update - the dependency version currently requires the concat module to be exactly equal to 0.1.0.  Given the popularity of that module, this causes conflicts with any larger deployments.  I made it so it requires a minimum of 0.1.0.

Thanks!
