### PR TITLE
Compatible with CentOS 6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,16 @@
 
 Module for provisioning DNS (bind9)
 
-Tested on Ubuntu 12.04, patches to support other operating systems are welcome.
+## Requirements
 
-This module depends on concat (https://github.com/ripienaar/puppet-concat).
+* [concat module](https://github.com/ripienaar/puppet-concat)
+* [line module](https://github.com/ahaitoute/puppet-line)
+
+## Tested on...
+
+* CentOS 6
+* Ubuntu 12.04
+* Patches to support other operating systems are welcome.
 
 Note: This module has moved on PuppetForge to [http://forge.puppetlabs.com/ajjahn/dns](http://forge.puppetlabs.com/ajjahn/dns). All future releases can be found there.
 

--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -9,7 +9,9 @@ define dns::record (
   $order = 9
 ) {
 
-  $zone_file = "/etc/bind/db.${zone}"
+  include dns::server::params
+
+  $zone_file = "${dns::server::params::dir}/db.${zone}"
 
   concat::fragment{"db.${zone}.${name}.record":
     target  => $zone_file,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,24 +1,15 @@
-class dns::server::config {
+class dns::server::config inherits dns::server::params {
 
-  file { '/etc/bind':
-    ensure => directory,
-    owner  => 'bind',
-    group  => 'bind',
-    mode   => '0755',
+  line { 'include_named.conf.local':
+    file    => "${confdir}/named.conf",
+    line    => "include \"${dir}/named.conf.local\";",
+    require => Package[$package],
+    notify  => Class['dns::server::service']
   }
 
-  file { '/etc/bind/named.conf':
-    ensure  => present,
-    owner   => 'bind',
-    group   => 'bind',
-    mode    => '0644',
-    require => [File['/etc/bind'], Class['dns::server::install']],
-    notify  => Class['dns::server::service'],
-  }
-
-  concat { '/etc/bind/named.conf.local':
-    owner   => 'bind',
-    group   => 'bind',
+  concat { "${dir}/named.conf.local":
+    owner   => $owner,
+    group   => $group,
     mode    => '0644',
     require => Class['concat::setup'],
     notify  => Class['dns::server::service']
@@ -26,7 +17,7 @@ class dns::server::config {
 
   concat::fragment{'named.conf.local.header':
     ensure  => present,
-    target  => '/etc/bind/named.conf.local',
+    target  => "${dir}/named.conf.local",
     order   => 1,
     content => "// File managed by Puppet.\n"
   }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -1,6 +1,6 @@
-class dns::server::install {
+class dns::server::install inherits dns::server::params {
 
-  package { 'bind9':
+  package { $package:
     ensure => latest,
   }
 

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -1,0 +1,22 @@
+class dns::server::params {
+
+  case $operatingsystem {
+    'CentOS', 'RedHat': {
+      $confdir = '/etc'
+      $dir = '/etc/named'
+      $group = 'named'
+      $owner = 'root'
+      $package = 'bind'
+      $service = 'named'
+    }
+    'Debian', 'Ubuntu': {
+      $dir = '/etc/bind'
+      $dir = '/etc/bind'
+      $group = 'bind'
+      $owner = 'bind'
+      $package = 'bind9'
+      $service = 'bind9'
+    }
+  }
+
+}

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -1,6 +1,6 @@
-class dns::server::service {
+class dns::server::service inherits dns::server::params {
 
-  service { 'bind9':
+  service { $service:
     ensure     => running,
     hasstatus  => true,
     hasrestart => true,


### PR DESCRIPTION
Hello Adam,

I've added CentOS 6-compatibility by placing the necessary variables in server/params.pp. Unfortunately I haven't got the time to install Ubuntu to test this branch, hopefully you can test this on Ubuntu before merging it.

To get the Bind-process include named.conf.local in CentOS, I've used the puppet-line-module (https://github.com/ahaitoute/puppet-line) to add the include named.conf.local-line entry in named.conf. I'm not sure if this can be handled by the concat-module and if this entry addition is also necessary in Ubuntu.
