### PR TITLE
Use FQDN as ptr name instead of octet

### DIFF
--- a/manifests/record/a.pp
+++ b/manifests/record/a.pp
@@ -17,9 +17,9 @@ define dns::record::a (
   if $ptr {
     $ip = inline_template('<%= data.kind_of?(Array) ? data.first : data %>')
     $reverse_zone = inline_template('<%= ip.split(".")[0..-2].reverse.join(".") %>.IN-ADDR.ARPA')
-    $octet = inline_template('<%= ip.split(".")[-1] %>')
+    $rrfqdn = inline_template('<%= ip.split(".").reverse.join(".") %>.IN-ADDR.ARPA')
 
-    dns::record::ptr { $octet:
+    dns::record::ptr { $rrfqdn:
       zone => $reverse_zone,
       data => "${host}.${zone}"
     }

--- a/manifests/record/ptr.pp
+++ b/manifests/record/ptr.pp
@@ -4,11 +4,17 @@ define dns::record::ptr (
   $ttl = '',
   $host = $name ) {
 
+  if $host =~ /IN-ADDR.ARPA$/ {
+    $hostdata = inline_template('<%= host.split(".")[0]%>')
+  } else {
+    $hostdata = $host
+  }
+  
   $alias = "${host},PTR,${zone}"
 
   dns::record { $alias:
     zone   => $zone,
-    host   => $host,
+    host   => $hostdata,
     ttl    => $ttl,
     record => 'PTR',
     data   => "${data}."


### PR DESCRIPTION
When multiple reverse zones are used and ptr records are generated from a records, the naming is not unique and causes errors.
I changed the PTR record handling a bit so that it uses FQDN instead of the last octet.
This solves errors like these when multiple reverse zones are used:

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: Dns::Record::Ptr[2] is already declared in file /etc/puppet/modules/dns/manifests/record/a.pp at line 25; cannot redeclare on node ...

I did not change the name of the resource definition, so i think it should not break existing configs.. Not tested though ! 

kr,
Stefan
