### PR TITLE
Solved Error 400 on SERVER: Syntax error at 'inherits' at /etc/puppet/modules/dns/manifests/server/options.pp:18:29

### DIFF
--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -18,7 +18,7 @@
 define dns::server::options (
   $forwarders = [],
 ) {
-
+  include dns::server::params
   file { $title:
     ensure  => present,
     owner   => $owner,


### PR DESCRIPTION
Hi guys,

I've recently updated my puppet git submodules and found a syntax error on this file:
Syntax error at 'inherits' at /etc/puppet/modules/dns/manifests/server/options.pp:18:29

puppet version: 3.3.1

It comes out when using the forwarders:

``` ruby
  # Forwarders to google dns
  dns::server::options{ '/etc/bind/named.conf.options':
    forwarders => [ '8.8.8.8', '8.8.4.4' ]
  }
```
