### PR TITLE
Support for multiple MX records with the same priority

### DIFF
--- a/manifests/record/mx.pp
+++ b/manifests/record/mx.pp
@@ -5,7 +5,7 @@ define dns::record::mx (
   $preference = '0',
   $host = $name ) {
 
-  $alias = "${host},MX,${zone}"
+  $alias = "${host},MX,${zone},${data}"
 
   dns::record { $alias:
     zone       => $zone,


### PR DESCRIPTION
According to the RFC (http://tools.ietf.org/html/rfc974), it is normal to have multiple MX records at the same priority. To support that, i made this small change on the MX record manifest.