### PR TITLE
Now a MX dns record includes the name parameter in the alias in order to...

### DIFF
--- a/manifests/record/mx.pp
+++ b/manifests/record/mx.pp
@@ -5,7 +5,7 @@ define dns::record::mx (
   $preference = '0',
   $host = $name ) {
 
-  $alias = "${host},MX,${zone}"
+  $alias = "${name},MX,${zone}"
 
   dns::record { $alias:
     zone       => $zone,


### PR DESCRIPTION
When adding more than one MX entries in puppet and declarating the host param it fails because the generated alias for the dns::record is not unique, example:
```
  dns::record::mx {
    'mydomain-mx-10':
      zone       => 'mydomain.com',
      host       => '@',
      preference => 10,
      data       => 'ASPMX.L.GOOGLE.com';
    'mydomain-mx-20':
      zone       => 'mydomain.com',
      host       => '@',
      preference => 20,
      data       => 'ALT2.ASPMX.L.GOOGLE.COM';
```
In mx.pp the generated alias is (where the $host parameter is $name if not specified)
```
$alias = "${host},MX,${zone}"
```
So in both two previous entries the alias would be the same: "@,MX,mydomain.com"

I've modified the alias "hash" variable, and setting $name instead of $host, because we already know that $name is unique in the user generated puppet manifest file:
```
$alias = "${name},MX,${zone}"
```

