### PR TITLE
Use FQDN as PTR name instead of octet

### DIFF
--- a/manifests/record/a.pp
+++ b/manifests/record/a.pp
@@ -19,7 +19,8 @@ define dns::record::a (
     $reverse_zone = inline_template('<%= @ip.split(".")[0..-2].reverse.join(".") %>.IN-ADDR.ARPA')
     $octet = inline_template('<%= @ip.split(".")[-1] %>')
 
-    dns::record::ptr { $octet:
+    dns::record::ptr { "$octet.${reverse_zone}":
+      host => $octet,
       zone => $reverse_zone,
       data => "${host}.${zone}"
     }


### PR DESCRIPTION
Alternate version of slapers pull request.

This patch need when we have multiple PTR zones. In a current state next code will create an exception:
dns::record::a {
 'dns1': zone => 'test', data => '192.168.10.1', ptr => true;
 'dns2': zone => 'test', data => '192.168.11.1', ptr => true;
}
