### PR TITLE
Fix 'Usage' section in dns::server::options

### DIFF
--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -12,7 +12,7 @@
 #
 # Sample Usage :
 #  dns::server::options { '/etc/bind/named.conf.options':
-#    'forwarders' => [ '8.8.8.8', '8.8.4.4' ],
+#    forwarders => [ '8.8.8.8', '8.8.4.4' ],
 #   }
 #
 define dns::server::options(


### PR DESCRIPTION
Parameter name should be without quotes
