### PR TITLE
added a dnssec_validation parameter, to avoid the creation of dnssec-val...

### DIFF
--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -22,6 +22,7 @@ define dns::server::options(
   $check_names_slave = undef,
   $check_names_response = undef,
   $allow_query = [],
+  $dnssec_validation = undef,
 ) {
   $valid_check_names = ['fail', 'warn', 'ignore']
 

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -53,7 +53,9 @@ check-names response <%= @check_names_response %>;
 	// If BIND logs error messages about the root key being expired,
 	// you will need to update your keys.  See https://www.isc.org/bind-keys
 	//========================================================================
+<% if @dnssec_validation -%>
 	dnssec-validation auto;
+<% end -%>
 
 	auth-nxdomain no;    # conform to RFC1035
 	listen-on-v6 { any; };


### PR DESCRIPTION
...idation auto in the bind server options file (.e.g named.conf.options)

In my setup, i needed to delete the dnssec_validation from the named.conf.options file. Maybe this is also relevant for other people
