### PR TITLE
MX preference fix, unique alias, add tests

### DIFF
--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -17,6 +17,14 @@ define dns::record (
 
   $zone_file_stage = "${cfg_dir}/zones/db.${zone}.stage"
 
+  if $ttl !~ /^[0-9SsMmHhDdWw]+$/ and $ttl != '' {
+    fail("Define[dns::record]: TTL ${ttl} must be an integer within 0-2147483647 or explicitly specified time units, e.g. 1h30m.")
+  }
+
+  if is_integer($ttl) and !($ttl >= 0 and $ttl <= 2147483647) {
+    fail("Define[dns::record]: TTL ${ttl} must be an integer within 0-2147483647 or explicitly specified time units, e.g. 1h30m.")
+  }
+
   concat::fragment{"db.${zone}.${name}.record":
     target  => $zone_file_stage,
     order   => $order,

--- a/manifests/record/mx.pp
+++ b/manifests/record/mx.pp
@@ -1,15 +1,42 @@
 # == Define: dns::record::mx
 #
-# Wrapper for dns::record to set an XM record.
+# Wrapper for dns::record to set an MX record.
 #
 define dns::record::mx (
   $zone,
   $data,
-  $ttl = '',
-  $preference = '0',
-  $host = $name ) {
+  $ttl        = '',
+  $preference = 10,
+  $host       = '@' ) {
 
-  $alias = "${host},MX,${zone}"
+  $alias = "${host},${zone},MX,${preference},${data}"
+
+  validate_string($zone)
+  validate_string($data)
+  validate_string($host)
+
+  if !is_domain_name($zone) or $zone =~ /^[0-9\.]+$/ {
+    fail("Define[dns::record::mx]: MX zone ${zone} must be a valid domain name.")
+  }
+  # Highest label (top-level domain) must be alphabetic
+  if $zone =~ /\./ and $zone !~ /\.[A-Za-z]+$/ {
+    fail("Define[dns::record::mx]: MX zone ${zone} must be a valid domain name.")
+  }
+  # RR data must be a valid hostname, not entirely numeric values
+  if !is_domain_name($data) or $data =~ /^[0-9\.]+$/ {
+    fail("Define[dns::record::mx]: MX data ${data} must be a valid hostname.")
+  }
+  if !is_integer($preference) or $preference < 0 or $preference > 65536 {
+    fail("Define[dns::record::mx]: preference ${preference} must be an integer within 0-65536.")
+  }
+  if !is_domain_name($host) and $host != '@' {
+    # Blank labels are permitted in BIND zone files, but they are not handled
+    # by this puppet module because it does not render concat fragments in an
+    # explicit order. Since BIND will substitute the last valid label, the
+    # resulting blank substitution would be unpredictable.
+    # Use @ to substitute the zone origin.
+    fail("Define[dns::record::mx]: MX host label ${host} must be a valid hostname or '@' to signify \$ORIGIN.")
+  }
 
   dns::record { $alias:
     zone       => $zone,

--- a/spec/defines/dns__record__mx_spec.rb
+++ b/spec/defines/dns__record__mx_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+describe 'dns::record::mx', :type => :define do
+  let(:title) { 'mxtest' }
+  let(:facts) { { :concat_basedir => '/tmp' } }
+
+  context 'passing an implicit origin' do
+    let :params do {
+        :zone => 'example.com',
+        :data => 'mailserver.example.com'
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.@,example.com,MX,10,mailserver.example.com.record').with_content(/^@\s+IN\s+MX\s+10\s+mailserver\.example\.com\.$/) }
+  end
+
+  context 'passing an explicit origin and preference' do
+    let :params do {
+        :zone       => 'example.com',
+        :data       => 'ittybittymx.example.com',
+        :host       => 'branchoffice',
+        :preference => 22
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.branchoffice,example.com,MX,22,ittybittymx.example.com.record').with_content(/^branchoffice\s+IN\s+MX\s+22\s+ittybittymx\.example\.com\.$/) }
+  end
+
+  context 'passing a wrong (out-of-range) preference' do
+    let :params do {
+        :zone       => 'example.com',
+        :data       => 'badpref.example.com',
+        :preference => 65537
+    } end
+
+    it { should raise_error(Puppet::Error, /must be an integer within 0-65536/) }
+  end
+
+  context 'passing a wrong (string) preference' do
+    let :params do {
+        :zone       => 'example.com',
+        :data       => 'worsepref.example.com',
+        :preference => 'highest'
+    } end
+
+    it { should raise_error(Puppet::Error, /must be an integer within 0-65536/) }
+  end
+  context 'passing a wrong (numeric top-level domain) zone' do
+    let :params do {
+        :zone => 'one.618',
+        :data => 'goldenratio.example.com'
+    } end
+
+    it { should raise_error(Puppet::Error, /must be a valid domain name/) }
+  end
+  context 'passing a wrong (numeric) zone' do
+    let :params do {
+        :zone => 123,
+        :data => 'badzone.example.com'
+    } end
+
+    it { should raise_error(Puppet::Error, /must be a valid domain name/) }
+  end
+  context 'passing a wrong (IP address) zone' do
+    let :params do {
+        :zone => '192.168.1.1',
+        :data => 'ipaddrzone.example.com'
+    } end
+
+    it { should raise_error(Puppet::Error, /must be a valid domain name/) }
+  end
+  context 'passing wrong (numeric) data' do
+    let :params do {
+        :zone => 'example.com',
+        :data => 456
+    } end
+
+    it { should raise_error(Puppet::Error, /must be a valid hostname/) }
+  end
+  context 'passing wrong (IP address) data' do
+    let :params do {
+        :zone => 'example.com',
+        :data => '192.168.4.4'
+    } end
+
+    it { should raise_error(Puppet::Error, /must be a valid hostname/) }
+  end
+end
+

--- a/spec/defines/dns__record_spec.rb
+++ b/spec/defines/dns__record_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'dns::record', :type => :define do
+  let(:title) { 'recordtest' }
+  let(:facts) { { :concat_basedir => '/tmp' } }
+
+  context 'passing a LOC record' do
+    let :params do {
+        :zone      => 'example.com',
+        :host      => 'saturnv',
+        :dns_class => 'IN',
+        :record    => 'LOC',
+        :data      => '34 42 40.126 N 86 39 21.248 W 203m 10m 100m 10m',
+        :ttl       => '1h45m10s'
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.recordtest.record').with_content(/^saturnv\s+1h45m10s\s+IN\s+LOC\s+34 42 40.126 N 86 39 21.248 W 203m 10m 100m 10m$/) }
+  end
+
+  context 'passing a wrong (out-of-range) TTL' do
+    let :params do {
+        :zone      => 'example.com',
+        :host      => 'badttl',
+        :dns_class => 'IN',
+        :record    => 'A',
+        :data      => '172.16.104.1',
+        :ttl       => 2147483648
+    } end
+    it { should raise_error(Puppet::Error, /must be an integer within 0-2147483647/) }
+  end
+
+  context 'passing a wrong (string) TTL' do
+    let :params do {
+        :zone      => 'example.com',
+        :host      => 'textttl',
+        :dns_class => 'IN',
+        :record    => 'A',
+        :data      => '172.16.104.2',
+         :ttl      => '4scoreand7years'
+    } end
+    it { should raise_error(Puppet::Error, /explicitly specified time units/) }
+  end
+
+end
+


### PR DESCRIPTION
Fixes ajjahn/puppet-dns#37
 - adds all fields to alias: host, zone, pref, and data
 - any three of the four can be the same for multiple MX records
   under management, which would previously cause a duplicate alias
 - add test to confirm concat fragment is named as expected

Fixes ajjahn/puppet-dns#39 by writing the promised tests

Other changes of note:
Default preference is now 10. A pref of 0 is allowed, but if a
DNS administrator wanted to insert a more-preferable MX record,
she would be unable to do so until the previous record TTL expired.

Default host is now '@'. This allows for cleaner manifests because
the most common MX case is to create an exchanger for the entire
$ORIGIN. BIND will do the substitution automatically.

Blank labels are permitted in zone files, but are not handled by
this module because it does not render concat fragments in an
explicit order. Since BIND will substitute the last valid label
for any blank label, the resulting substitution would be
unpredictable.