### PR TITLE
allow port to be customized in dns::server::options

### DIFF
--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -20,6 +20,7 @@
 define dns::server::options(
   $forwarders = [],
   $listen_on = [],
+  $listen_on_port = undef,
   $allow_recursion = [],
   $check_names_master = undef,
   $check_names_slave = undef,

--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -8,7 +8,8 @@
 # $listen_on:
 #   Array of IP addresses on which to listen. Default: empty, meaning "any"
 # $listen_on_port:
-#   UDP/TCP port number to use for receiving and sending traffic.  Default: undefined, meaning 53
+#   UDP/TCP port number to use for receiving and sending traffic.
+#   Default: undefined, meaning 53
 # $group:
 #   Group of the file. Default: bind
 # $owner:

--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -7,6 +7,8 @@
 #   Array of forwarders IP addresses. Default: empty
 # $listen_on:
 #   Array of IP addresses on which to listen. Default: empty, meaning "any"
+# $listen_on_port:
+#   UDP/TCP port number to use for receiving and sending traffic.  Default: undefined, meaning 53
 # $group:
 #   Group of the file. Default: bind
 # $owner:

--- a/spec/defines/dns__server__options_spec.rb
+++ b/spec/defines/dns__server__options_spec.rb
@@ -47,16 +47,7 @@ describe 'dns::server::options', :type => :define do
       { :listen_on_port => 5300 }
     end
 
-    it { should contain_file('/etc/bind/named.conf.options').with_content(/listen-on port 5300 { any; };/)  }
-
-  end
-
-  context 'passing custom port to listen_on_port and valid array to listen_on' do
-    let :params do
-      { :listen_on_port => 5300, :listen_on => [ '10.11.12.13' ] }
-    end
-
-    it { should contain_file('/etc/bind/named.conf.options').with_content(/listen-on port 5300 {\s+10\.11\.12\.13;\s+};/)  }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/port 5300;/)  }
 
   end
 

--- a/spec/defines/dns__server__options_spec.rb
+++ b/spec/defines/dns__server__options_spec.rb
@@ -42,6 +42,24 @@ describe 'dns::server::options', :type => :define do
 
   end
 
+  context 'passing custom port to listen_on_port' do
+    let :params do
+      { :listen_on_port => 5300 }
+    end
+
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/listen-on port 5300 { any; };/)  }
+
+  end
+
+  context 'passing custom port to listen_on_port and valid array to listen_on' do
+    let :params do
+      { :listen_on_port => 5300, :listen_on => [ '10.11.12.13' ] }
+    end
+
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/listen-on port 5300 {\s+10\.11\.12\.13;\s+};/)  }
+
+  end
+
   context 'passing a string to listen_on' do
     let :params do
       { :listen_on => '10.9.8.7' }

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -22,12 +22,16 @@ options {
 <% end -%>
 
 <% if @listen_on.size == 0 then -%>
-    listen-on <%- if @listen_on_port %>port <%= @listen_on_port %><% end -%> { any; };
+    listen-on { any; };
 <% else -%>
-    listen-on <%- if @listen_on_port %>port <%= @listen_on_port %><% end -%> {
+    listen-on {
     <% @listen_on.each do |ipv4_addr| -%>
       <%= ipv4_addr -%>;
     <% end -%>};
+<% end -%>
+
+<% if @listen_on_port -%>
+    port <%= @listen_on_port %>;
 <% end -%>
 
 <% if @allow_recursion.size != 0 then -%>

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -22,9 +22,9 @@ options {
 <% end -%>
 
 <% if @listen_on.size == 0 then -%>
-    listen-on { any; };
+    listen-on <%- if @listen_on_port %>port <%= @listen_on_port %><% end -%> { any; };
 <% else -%>
-    listen-on {
+    listen-on <%- if @listen_on_port %>port <%= @listen_on_port %><% end -%> {
     <% @listen_on.each do |ipv4_addr| -%>
       <%= ipv4_addr -%>;
     <% end -%>};


### PR DESCRIPTION
I've added a `$listen_on_port` option to `dns::server::options` to allow the port to be customized.  Rspec tests included.