### PR TITLE
Added integration test with a full example host on redhat. Addresses #78

### DIFF
--- a/spec/fixtures/manifests/site.pp
+++ b/spec/fixtures/manifests/site.pp
@@ -1,0 +1,21 @@
+
+node 'testhost.example.com' {
+  include dns::server
+  dns::zone { 'example.com':
+   soa         => 'ns1.example.com',
+   soa_email   => 'admin.example.com',
+   nameservers => ['ns1.example.com']
+  }
+  dns::zone { '1.168.192.IN-ADDR.ARPA':
+   soa         => 'ns1.example.com',
+   soa_email   => 'admin.example.com',
+   nameservers => ['ns1.example.com']
+  }
+  dns::record::a { 'ns1':
+   zone => 'example.com',
+   data => ['192.168.1.1'],
+   ptr  => true;
+  }
+}
+
+node default {}

--- a/spec/hosts/example_spec.rb
+++ b/spec/hosts/example_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'testhost.example.com' do
+
+  let(:facts) {{ :osfamily => 'RedHat', :concat_basedir  => '/dne', :define_fact => "" }}
+
+  context 'When given connected records that depend on each other' do
+    it { should compile }
+  end
+
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,8 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |c|
+  c.before do
+    # avoid "Only root can execute commands as other users"
+    Puppet.features.stubs(:root? => true)
+  end
+end


### PR DESCRIPTION
@robertdebock this adds a failing integration to cover exactly the bob exposed in #78.

However... I don't know what the deal is. It works if I set the facts to "debian".

It is like concat might be having trouble with the comma in the filename? I'm really not sure.