### PR TITLE
Fixed a bug where key did not work on redhat due to incorrect pkg name

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -15,7 +15,7 @@ define dns::key {
     command     => "/usr/sbin/dnssec-keygen -a HMAC-MD5 -r /dev/urandom -b 128 -n USER ${name}",
     cwd         => "${cfg_dir}/bind.keys.d",
     require     => [
-      Package['dnssec-tools','bind9'],
+      Package['dnssec-tools',$package],
       File["${cfg_dir}/bind.keys.d"],
     ],
     refreshonly => true,

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -15,7 +15,7 @@ define dns::key {
     command     => "/usr/sbin/dnssec-keygen -a HMAC-MD5 -r /dev/urandom -b 128 -n USER ${name}",
     cwd         => "${cfg_dir}/bind.keys.d",
     require     => [
-      Package['dnssec-tools',$dns::server::params::package],
+      Package['dnssec-tools'],
       File["${cfg_dir}/bind.keys.d"],
     ],
     refreshonly => true,

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -15,7 +15,7 @@ define dns::key {
     command     => "/usr/sbin/dnssec-keygen -a HMAC-MD5 -r /dev/urandom -b 128 -n USER ${name}",
     cwd         => "${cfg_dir}/bind.keys.d",
     require     => [
-      Package['dnssec-tools',$package],
+      Package['dnssec-tools',$dns::server::params::package],
       File["${cfg_dir}/bind.keys.d"],
     ],
     refreshonly => true,


### PR DESCRIPTION
Replaced the hardcoded package name with the package variable.