### PR TITLE
Added in feature allowing for global allow-transfer

### DIFF
--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -7,6 +7,9 @@
 # [*forwarders*]
 #   Array of forwarders IP addresses. Default: empty
 #
+# [*transfers*]
+#   Array of IP addresses or "none" allowed to transfer. Default: empty
+#
 # [*listen_on*]
 #   Array of IP addresses on which to listen. Default: empty, meaning "any"
 #
@@ -42,6 +45,7 @@
 #
 define dns::server::options (
   $forwarders = [],
+  $transfers = [],
   $listen_on = [],
   $listen_on_port = undef,
   $allow_recursion = [],
@@ -58,6 +62,7 @@ define dns::server::options (
   }
 
   validate_array($forwarders)
+  validate_array($transfers)
   validate_array($listen_on)
   validate_array($allow_recursion)
   if $check_names_master != undef and !member($valid_check_names, $check_names_master) {

--- a/spec/defines/dns__server__options_spec.rb
+++ b/spec/defines/dns__server__options_spec.rb
@@ -23,12 +23,36 @@ describe 'dns::server::options', :type => :define do
 
   end
 
+  context 'passing valid array to transfers' do
+    let :params do
+      { :transfers => ['192.168.0.3', '192.168.0.4'] }
+    end
+
+    it { should contain_file('/etc/bind/named.conf.options') }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/192\.168\.0\.3;$/) }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/192\.168\.0\.4;$/) }
+    it { should contain_file('/etc/bind/named.conf.options').with_ensure("present") }
+    it { should contain_file('/etc/bind/named.conf.options').with_owner("bind") }
+    it { should contain_file('/etc/bind/named.conf.options').with_group("bind") }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/allow-transfer/) }
+
+  end
+
   context 'passing a string to forwarders' do
     let :params do
       { :forwarders => '8.8.8.8' }
     end
 
     it { should raise_error(Puppet::Error, /is not an Array/) }
+
+  end
+
+  context 'passing a string to transfers' do
+    let :params do
+      { :transfers => '192.168.0.3' }
+    end
+
+  it { should raise_error(Puppet::Error, /is not an Array/) }
 
   end
 

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -21,6 +21,13 @@ options {
     <% end -%>};
 <% end -%>
 
+<% if @transfers.size != 0 then -%>
+    allow-transfer {
+    <% @transfers.each do |transfer| -%>
+      <%= transfer -%>;
+    <% end -%>};
+<% end -%>
+
 <% if @listen_on.size == 0 then -%>
     listen-on { any; };
 <% else -%>


### PR DESCRIPTION
Would you guys find this useful? It looked like existing allow-transfer feature was for the zone level only. We have some need for global allow-transfer, so I added this in. Based the unit tests on the forwarders tests.