### PR TITLE
Added in a feature to allow zones files to have supplementary files

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -16,7 +16,8 @@ define dns::zone (
   $forward_policy = 'first',
   $slave_masters = undef,
   $zone_notify = false,
-  $ensure = present
+  $ensure = present,
+  $supplementary = false
 ) {
 
   $cfg_dir = $dns::server::params::cfg_dir
@@ -41,6 +42,9 @@ define dns::zone (
 
   if $ensure == absent {
     file { $zone_file:
+      ensure => absent,
+    }
+    file { "$zone_file.supplementary":
       ensure => absent,
     }
   } else {
@@ -82,6 +86,18 @@ define dns::zone (
     target  => "${cfg_dir}/named.conf.local",
     order   => 3,
     content => template("${module_name}/zone.erb")
+  }
+
+    # This ensures the supplementary zone file is present, even if it is just a blank one
+  if $supplementary == true {
+    file {"$zone_file.supplementary":
+      replace => 'no',
+      ensure  => 'present',
+      content => '; Supplementary file from Puppet\n',
+      owner   => "$group",
+      group   => "$owner",
+      mode    => '0744',
+    }
   }
 
 }

--- a/spec/defines/dns__zone_spec.rb
+++ b/spec/defines/dns__zone_spec.rb
@@ -80,7 +80,34 @@ describe 'dns::zone' do
                   with_content(/forward only;/)
           end
       end
+      
+      context 'when ask to have supplementary zone' do
+          let :params do {
+              :supplementary => true
+          }
+          end
 
+          it {
+              should contain_file('/etc/bind/zones/db.test.com.supplementary').with({
+                  'ensure' => 'present',
+                  'replace' => 'no',
+              }).with_content(/; Supplementary file from Puppet/)
+          }
+      end
+
+      context 'when not asked to have supplementary zone' do
+          let :params do {
+              :ensure => 'absent'
+          }
+          end
+
+          it {
+              should contain_file('/etc/bind/zones/db.test.com.supplementary').with({
+                  'ensure' => 'absent',
+              })
+          }
+      end
+      
       context 'with no explicit forward policy or forwarder' do
           let(:params) {{ :allow_transfer => ['192.0.2.0', '2001:db8::/32'] }}
 
@@ -89,6 +116,7 @@ describe 'dns::zone' do
                   with_content(/forward/)
           end
       end
+      
       context 'with a forward zone' do
           let :params do
               { :allow_transfer => ['123.123.123.123'],

--- a/templates/zone_file.erb
+++ b/templates/zone_file.erb
@@ -15,3 +15,6 @@ $TTL	<%= @zone_ttl %>
 @		IN	NS	<%= nameserver -%>.
 <% end -%>
 ;
+<% if @supplementary == true %>
+$INCLUDE db.<%= zone %>.supplementary;
+<% end -%>


### PR DESCRIPTION
In our environment some of our records are generated by a script with data pulled from a database, and it writes these out to files BIND then reads. There seemed to be no easy way to support that workflow with this module, so I added in the idea of a supplementary file.

The user can specify that a zone will have a supplementary file, and if so, it just adds an include directive (and deploys a blank file to avoid BIND errors) to include the file, and then you can overwrite that file with whatever records desired.

I am not sure if you think this is appropriate for the general use module or useful for your users, but I figured I would give you a pull request for it in case you wanted to include it.
