### PR TITLE
Added in support for allow-update for zones

### DIFF
--- a/templates/zone.erb
+++ b/templates/zone.erb
@@ -16,6 +16,13 @@ type <%= @zone_type %>;
         <% end -%>
         };
     <% end -%>
+    <% if @allow_update -%>
+        allow-update {
+        <% @allow_update.each do |ip| -%>
+            <%= ip %>;
+        <% end -%>
+        };
+    <% end %>
 <% end -%>
 <% if !@allow_forwarder.empty? and ( @zone_type == 'master' or  @zone_type == 'forward') -%>
     forward <%= @forward_policy %>;


### PR DESCRIPTION
I needed support for allowing a zone to be updated dynamically, so I put this in. I made sure that the module will not overwrite a file while it is allowing updates from an IP, as that would overwrite the dynamic leases. Also preventing it from bumping the zone serial while it is accepting updates.
