### PR TITLE
spec tests: fix invalid range in regexp

### DIFF
--- a/spec/defines/dns__server__options_spec.rb
+++ b/spec/defines/dns__server__options_spec.rb
@@ -98,7 +98,7 @@ describe 'dns::server::options', :type => :define do
     end
 
     it { should contain_file('/etc/bind/named.conf.options').with_content(/10\.0\.0\.1;$/) }
-    it { should contain_file('/etc/bind/named.conf.options').with_content(/allow-recursion {$/) }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/allow-recursion \{$/) }
 
   end
 


### PR DESCRIPTION
The rake tests fail because of an invalid regexp on line 101 of `spec/defines/dns__server__options_spec.rb`.  I escaped the bare `{` in that regexp:

    it { should contain_file('/etc/bind/named.conf.options').with_content(/allow-recursion \{$/) }
