### PR TITLE
zone files should only be created or modified for master zones

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -43,7 +43,7 @@ define dns::zone (
     file { $zone_file:
       ensure => absent,
     }
-  } else {
+  } elsif $zone_type == 'master' {
     # Zone Database
 
     # Create "fake" zone file without zone-serial
@@ -73,6 +73,12 @@ define dns::zone (
       group       => $dns::server::params::group,
       require     => Class['dns::server::install'],
       notify      => Class['dns::server::service'],
+    }
+  } else {
+    # For any zone file that is not a master zone, we should make sure
+    # we don't have a staging file
+    concat { $zone_file_stage:
+      ensure => absent
     }
   }
 

--- a/spec/defines/dns__zone_spec.rb
+++ b/spec/defines/dns__zone_spec.rb
@@ -104,7 +104,7 @@ describe 'dns::zone' do
           end
           it 'should not have allow_tranfer entry' do
               should_not contain_concat__fragment('named.conf.local.test.com.include').
-                         with_content(/allow_transfer/)
+                         with_content(/allow-transfer/)
           end
           it 'should not have file entry' do
               should_not contain_concat__fragment('named.conf.local.test.com.include').
@@ -118,8 +118,10 @@ describe 'dns::zone' do
               should contain_concat__fragment('named.conf.local.test.com.include').
                              with_content(/forwarders/)
           end
-          it 'should not have a zone file concat' do
-              should_not contain_concat('/etc/bind/zones/db.test.com.stage')
+          it 'should have an "absent" zone file concat' do
+              should contain_concat('/etc/bind/zones/db.test.com.stage').with({
+                  :ensure => "absent"
+              })
           end
       end
 
@@ -143,14 +145,16 @@ describe 'dns::zone' do
           end
           it 'should not have allow_tranfer entry' do
               should_not contain_concat__fragment('named.conf.local.test.com.include').
-                         with_content(/allow_transfer/)
+                         with_content(/allow-transfer/)
           end
           it 'should not have any forward information' do
               should_not contain_concat__fragment('named.conf.local.test.com.include').
                              with_content(/forward/)
           end
-          it 'should not have a zone file concat' do
-              should_not contain_concat('/etc/bind/zones/db.test.com.stage')
+          it 'should have an "absent" zone file concat' do
+              should contain_concat('/etc/bind/zones/db.test.com.stage').with({
+                  :ensure => "absent"
+              })
           end
       end
 
@@ -176,7 +180,7 @@ describe 'dns::zone' do
           end
           it 'should have allow_tranfer entry' do
               should contain_concat__fragment('named.conf.local.test.com.include').
-                         with_content(/allow_transfer/)
+                         with_content(/allow-transfer/)
           end
           it 'should have a forward-policy entry' do
               should contain_concat__fragment('named.conf.local.test.com.include').
@@ -187,7 +191,9 @@ describe 'dns::zone' do
                              with_content(/forwarders/)
           end
           it 'should have a zone file concat' do
-              should contain_concat('/etc/bind/zones/db.test.com.stage')
+              should contain_concat('/etc/bind/zones/db.test.com.stage').with({
+                  :ensure => "present"
+              })
           end
       end
 

--- a/spec/defines/dns__zone_spec.rb
+++ b/spec/defines/dns__zone_spec.rb
@@ -89,6 +89,7 @@ describe 'dns::zone' do
                   with_content(/forward/)
           end
       end
+
       context 'with a forward zone' do
           let :params do
               { :allow_transfer => ['123.123.123.123'],
@@ -117,7 +118,80 @@ describe 'dns::zone' do
               should contain_concat__fragment('named.conf.local.test.com.include').
                              with_content(/forwarders/)
           end
+          it 'should not have a zone file concat' do
+              should_not contain_concat('/etc/bind/zones/db.test.com.stage')
+          end
       end
+
+      context 'with a slave zone' do
+          let :params do
+              { :slave_masters => ['123.123.123.123'],
+                :zone_type => 'slave'
+              }
+          end
+          it 'should have a type slave entry' do
+              should contain_concat__fragment('named.conf.local.test.com.include').
+                         with_content(/type slave/)
+          end
+          it 'should have file entry' do
+              should contain_concat__fragment('named.conf.local.test.com.include').
+                             with_content(/file/)
+          end
+          it 'should have masters entry' do
+              should contain_concat__fragment('named.conf.local.test.com.include').
+                             with_content(/masters/)
+          end
+          it 'should not have allow_tranfer entry' do
+              should_not contain_concat__fragment('named.conf.local.test.com.include').
+                         with_content(/allow_transfer/)
+          end
+          it 'should not have any forward information' do
+              should_not contain_concat__fragment('named.conf.local.test.com.include').
+                             with_content(/forward/)
+          end
+          it 'should not have a zone file concat' do
+              should_not contain_concat('/etc/bind/zones/db.test.com.stage')
+          end
+      end
+
+      context 'with a master zone' do
+          let :params do
+              { :allow_transfer => ['8.8.8.8','8.8.4.4'],
+                :allow_forwarder => ['8.8.8.8', '208.67.222.222'],
+                :forward_policy => 'only',
+                :zone_type => 'master'
+              }
+          end
+          it 'should have a type master entry' do
+              should contain_concat__fragment('named.conf.local.test.com.include').
+                         with_content(/type master/)
+          end
+          it 'should have file entry' do
+              should contain_concat__fragment('named.conf.local.test.com.include').
+                             with_content(/file/)
+          end
+          it 'should not have masters entry' do
+              should_not contain_concat__fragment('named.conf.local.test.com.include').
+                             with_content(/masters/)
+          end
+          it 'should have allow_tranfer entry' do
+              should contain_concat__fragment('named.conf.local.test.com.include').
+                         with_content(/allow_transfer/)
+          end
+          it 'should have a forward-policy entry' do
+              should contain_concat__fragment('named.conf.local.test.com.include').
+                             with_content(/forward /)
+          end
+          it 'should have a forwarders entry' do
+              should contain_concat__fragment('named.conf.local.test.com.include').
+                             with_content(/forwarders/)
+          end
+          it 'should have a zone file concat' do
+              should contain_concat('/etc/bind/zones/db.test.com.stage')
+          end
+      end
+
+
   end
 end
 


### PR DESCRIPTION
The `zone.pp` class should not be allowed to create or modify the zone file for a slave zone at all.  It should only manage master zone files.

I just added in a check to `zone.pp` so it only creates the `concat` type for master files, for all others it sets the `concat` to `ensure => absent`.