### PR TITLE
Use resource names instead of hosts for the aliases of dns record types.  With spec test file.

### DIFF
--- a/manifests/record/a.pp
+++ b/manifests/record/a.pp
@@ -10,7 +10,7 @@ define dns::record::a (
   $ptr = false,
   $host = $name ) {
 
-  $alias = "${host},A,${zone}"
+  $alias = "${name},A,${zone}"
 
   dns::record { $alias:
     zone => $zone,

--- a/manifests/record/aaaa.pp
+++ b/manifests/record/aaaa.pp
@@ -8,7 +8,7 @@ define dns::record::aaaa (
   $ttl = '',
   $host = $name ) {
 
-  $alias = "${host},AAAA,${zone}"
+  $alias = "${name},AAAA,${zone}"
 
   dns::record { $alias:
     zone   => $zone,

--- a/manifests/record/cname.pp
+++ b/manifests/record/cname.pp
@@ -8,7 +8,7 @@ define dns::record::cname (
   $ttl = '',
   $host = $name) {
 
-  $alias = "${host},CNAME,${zone}"
+  $alias = "${name},CNAME,${zone}"
 
   $qualified_data = $data ? {
     '@'     => $data,

--- a/manifests/record/mx.pp
+++ b/manifests/record/mx.pp
@@ -9,7 +9,7 @@ define dns::record::mx (
   $preference = 10,
   $host       = '@' ) {
 
-  $alias = "${host},${zone},MX,${preference},${data}"
+  $alias = "${name},${zone},MX,${preference},${data}"
 
   validate_string($zone)
   validate_string($data)

--- a/manifests/record/ns.pp
+++ b/manifests/record/ns.pp
@@ -8,7 +8,7 @@ define dns::record::ns (
   $ttl = '',
   $host = $name ) {
 
-  $alias = "${host},NS,${zone}"
+  $alias = "${name},NS,${zone}"
 
   dns::record { $alias:
     zone   => $zone,

--- a/manifests/record/ptr.pp
+++ b/manifests/record/ptr.pp
@@ -9,7 +9,7 @@ define dns::record::ptr (
   $host = $name
 ) {
 
-  $alias = "${host},PTR,${zone}"
+  $alias = "${name},PTR,${zone}"
 
   dns::record { $alias:
     zone   => $zone,

--- a/manifests/record/txt.pp
+++ b/manifests/record/txt.pp
@@ -8,7 +8,7 @@ define dns::record::txt (
   $ttl = '',
   $host = $name) {
 
-  $alias = "${host},TXT,${zone}"
+  $alias = "${name},TXT,${zone}"
 
   dns::record { $alias:
     zone   => $zone,

--- a/spec/defines/dns__record__aliases.spec.rb
+++ b/spec/defines/dns__record__aliases.spec.rb
@@ -1,0 +1,217 @@
+require 'spec_helper'
+
+describe 'dns::record::aaaa', :type => :define do
+  let(:facts) { { :concat_basedir => '/tmp' } }
+
+  context 'letting the host be defined by the resource name' do
+    let :params do {
+        :zone => 'example.com',
+        :title => 'foo' ,
+        :data => ['::1'] ,
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.foo,AAAA,example.com.record')
+      .with_content(/^foo\s+IN\s+AAAA\s+::1$/)
+     }
+  end
+
+  context 'assigning a different host than the resource name' do
+    let :params do {
+        :zone => 'example.com',
+        :title => 'foo' ,
+        :host => 'bar' ,
+        :data => ['::1'] ,
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.foo,AAAA,example.com.record')
+      .with_content(/^bar\s+IN\s+AAAA\s+::1$/)
+     }
+  end
+
+end
+
+describe 'dns::record::a', :type => :define do
+  let(:facts) { { :concat_basedir => '/tmp' } }
+
+  context 'letting the host be defined by the resource name' do
+    let :params do {
+        :zone => 'example.com',
+        :title => 'foo' ,
+        :data => ['1.2.3.4'] ,
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.foo,A,example.com.record')
+      .with_content(/^foo\s+IN\s+A\s+1\.2\.3\.4$/)
+     }
+  end
+
+  context 'assigning a different host than the resource name' do
+    let :params do {
+        :zone => 'example.com',
+        :title => 'foo' ,
+        :host => 'bar' ,
+        :data => ['1.2.3.4'] ,
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.foo,A,example.com.record')
+      .with_content(/^bar\s+IN\s+A\s+1\.2\.3\.4$/)
+     }
+  end
+
+end
+
+describe 'dns::record::cname', :type => :define do
+  let(:facts) { { :concat_basedir => '/tmp' } }
+
+  context 'letting the host be defined by the resource name' do
+    let :params do {
+        :zone => 'example.com',
+        :title => 'foo' ,
+        :data => 'baz.example.com',
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.foo,CNAME,example.com.record')
+      .with_content(/^foo\s+IN\s+CNAME\s+baz\.example\.com\.$/)
+     }
+  end
+
+  context 'assigning a different host than the resource name' do
+    let :params do {
+        :zone => 'example.com',
+        :title => 'foo' ,
+        :host => 'bar' ,
+        :data => 'baz.example.com',
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.foo,CNAME,example.com.record')
+      .with_content(/^bar\s+IN\s+CNAME\s+baz\.example\.com\.$/)
+     }
+  end
+
+end
+
+describe 'dns::record::mx', :type => :define do
+  let(:facts) { { :concat_basedir => '/tmp' } }
+
+  context 'letting the host be defined by the resource name' do
+    let :params do {
+        :zone => 'example.com',
+        :title => 'foo' ,
+        :data => 'baz.example.com',
+        :preference => 10,
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.foo,MX,example.com.record')
+      .with_content(/^foo\s+IN\s+MX\s+10\s+baz\.example\.com\.$/)
+     }
+  end
+
+  context 'assigning a different host than the resource name' do
+    let :params do {
+        :zone => 'example.com',
+        :title => 'foo' ,
+        :host => 'bar' ,
+        :data => 'baz.example.com',
+        :preference => 10,
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.foo,MX,example.com.record')
+      .with_content(/^bar\s+IN\s+MX\s+10\s+baz\.example\.com\.$/)
+     }
+  end
+
+end
+
+
+describe 'dns::record::ns', :type => :define do
+  let(:facts) { { :concat_basedir => '/tmp' } }
+
+  context 'letting the host be defined by the resource name' do
+    let :params do {
+        :zone => 'example.com',
+        :title => 'foo' ,
+        :data => 'baz.example.com.',
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.foo,NS,example.com.record')
+      .with_content(/^foo\s+IN\s+NS\s+baz\.example\.com\.$/)
+     }
+  end
+
+  context 'assigning a different host than the resource name' do
+    let :params do {
+        :zone => 'example.com',
+        :title => 'foo' ,
+        :host => 'bar' ,
+        :data => 'baz.example.com.',
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.foo,NS,example.com.record')
+      .with_content(/^bar\s+IN\s+NS\s+baz\.example\.com\.$/)
+     }
+  end
+
+end
+
+
+describe 'dns::record::ptr', :type => :define do
+  let(:facts) { { :concat_basedir => '/tmp' } }
+
+  context 'letting the host be defined by the resource name' do
+    let :params do {
+        :zone => '0.0.127.IN-ADDR.ARPA',
+        :title => '1' ,
+        :data => 'localhost',
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.0.0.127.IN-ADDR.ARPA.1,PTR,0.0.127.IN-ADDR.ARPA.record')
+      .with_content(/^1\s+IN\s+PTR\s+localhost\.$/)
+     }
+  end
+
+  context 'assigning a different host than the resource name' do
+    let :params do {
+        :zone => '0.0.127.IN-ADDR.ARPA',
+        :title => 'foo' ,
+        :host => '1' ,
+        :data => 'localhost',
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.0.0.127.IN-ADDR.ARPA.foo,PTR,0.0.127.IN-ADDR.ARPA.record')
+      .with_content(/^1\s+IN\s+PTR\s+localhost\.$/)
+     }
+  end
+
+end
+
+
+describe 'dns::record::txt', :type => :define do
+  let(:facts) { { :concat_basedir => '/tmp' } }
+
+  context 'letting the host be defined by the resource name' do
+    let :params do {
+        :zone => 'example.com',
+        :title => 'foo' ,
+        :data => 'baz',
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.foo,TXT,example.com.record')
+      .with_content(/^foo\s+IN\s+TXT\s+"baz"$/)
+     }
+  end
+
+  context 'assigning a different host than the resource name' do
+    let :params do {
+        :zone => 'example.com',
+        :title => 'foo' ,
+        :host => 'bar' ,
+        :data => 'baz.example.com',
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.foo,TXT,example.com.record')
+      .with_content(/^bar\s+IN\s+TXT\s+"baz"$/)
+     }
+  end
+
+end
+

--- a/spec/defines/dns__record__mx_spec.rb
+++ b/spec/defines/dns__record__mx_spec.rb
@@ -10,7 +10,7 @@ describe 'dns::record::mx', :type => :define do
         :data => 'mailserver.example.com'
     } end
     it { should_not raise_error }
-    it { should contain_concat__fragment('db.example.com.@,example.com,MX,10,mailserver.example.com.record').with_content(/^@\s+IN\s+MX\s+10\s+mailserver\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.example.com.mxtest,example.com,MX,10,mailserver.example.com.record').with_content(/^@\s+IN\s+MX\s+10\s+mailserver\.example\.com\.$/) }
   end
 
   context 'passing an explicit origin and preference' do
@@ -21,7 +21,7 @@ describe 'dns::record::mx', :type => :define do
         :preference => 22
     } end
     it { should_not raise_error }
-    it { should contain_concat__fragment('db.example.com.branchoffice,example.com,MX,22,ittybittymx.example.com.record').with_content(/^branchoffice\s+IN\s+MX\s+22\s+ittybittymx\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.example.com.mxtest,example.com,MX,22,ittybittymx.example.com.record').with_content(/^branchoffice\s+IN\s+MX\s+22\s+ittybittymx\.example\.com\.$/) }
   end
 
   context 'passing a wrong (out-of-range) preference' do


### PR DESCRIPTION
I noticed that the current resource definitions in the `dns::record::`* classes all base their resource names on the zonefile host entry.  This means that you cannot create multiple entries of the same type for the same name.

Admittedly,most of the entries allow for an array for the data parameter, but there's one case where this doesn't work:  automatic ptr entry creation.

Suppose I want to create these DNS zones fragments:

    foo     IN A    192.168.100.101
    foo     IN A    192.168.100.102

...and...

    101    IN PTR    foo.example.com.
    102    IN PTR    foo.example.com.

Under the current code, I would not be able to use the automatic PTR record generation for this, because I would have to use a two-item array for the data of the A record, but the automatic PTR generation only looks at the first IP address.

This PR changes the alias definitions for the record type to use `${name}` instead of `${host}`.  This would allow me to give the two A records different names but use the same host entry in both, and I would get my automatic PTR generation:

    dns::record::a { "foo,101":    # generates alias foo,101,A,example.com
        host => "foo" ,
        zone => "example.com" ,
        data => [ "192.168.100.101" ] ,
        ptr => true
    }
    
    dns::record::a { "foo,102":    # generates alias foo,102,A,example.com
        host => "foo" ,
        zone => "example.com" ,
        data => [ "192.168.100.102" ] ,
        ptr => true
    }

This also allows, in general, for the (to me) more obvious style of having two resource definitions if I want to create two records of the same name, whether it's for A records, NS records, TXT records, etc.

MX records already allow this, but I made the change to them also to be consistent.  The only record type I did not change was the SRV record type, since I don't understand the semantics of the SRV records.

I also created a spec file to test all the record types that use the new alias construction, to ensure they create the proper fragment name and proper record entry both when using the alias for the host and when specifying a different host, and I adjusted the `dns__record__mx_spec.rb` tests to match the new expected fragment names.