### PR TITLE
Control named.conf

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -29,16 +29,35 @@ class dns::server::config (
     mode   => '0755',
   }
 
-  file { $cfg_file:
-    ensure  => present,
-    owner   => $owner,
-    group   => $group,
-    mode    => '0644',
-    require => [
-      File[$cfg_dir],
-      Class['dns::server::install']
-    ],
-    notify  => Class['dns::server::service'],
+  case $::osfamily {
+    'RedHat': {
+      file { $cfg_file:
+        ensure  => present,
+        owner   => $owner,
+        group   => $group,
+        mode    => '0644',
+        content => template("${module_name}/named.conf.erb"),
+        require => [
+          File[$cfg_dir],
+          Class['dns::server::install']
+        ],
+        notify  => Class['dns::server::service'],
+      }
+    }
+    'Debian': {
+      file { $cfg_file:
+        ensure  => present,
+        owner   => $owner,
+        group   => $group,
+        mode    => '0644',
+        require => [
+          File[$cfg_dir],
+          Class['dns::server::install']
+        ],
+        notify  => Class['dns::server::service'],
+      }
+    }
+    default: { fail('Unrecognized operating system') }
   }
 
   concat { "${cfg_dir}/named.conf.local":

--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -56,6 +56,7 @@ define dns::server::options (
 ) {
   $valid_check_names = ['fail', 'warn', 'ignore']
   $cfg_dir = $::dns::server::params::cfg_dir
+  $data_dir = $::dns::server::params::data_dir
 
   if ! defined(Class['::dns::server']) {
     fail('You must include the ::dns::server base class before using any dns options defined resources')

--- a/spec/classes/dns__server__config_spec.rb
+++ b/spec/classes/dns__server__config_spec.rb
@@ -18,6 +18,25 @@ describe 'dns::server::config', :type => :class do
 
     it { should contain_file('/etc/bind/').with_owner('bind') }
   end
-
+  context "on a RedHat OS" do
+    let :facts do
+      {
+        :osfamily => 'RedHat'
+      }
+    end
+    let :params do
+      {
+        :owner => 'named',
+        :group => 'named',
+      }
+    end
+    it { should contain_file('/etc/named.conf').with({
+      'ensure' => 'present',
+      'owner'  => 'named',
+      'group'  => 'named',
+      'mode'   => '0644',
+    })
+    it shoud contain_file('/etc/named.conf').with_content("/^include /etc/named/named.conf.options;$/")
+  end
 end
 

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -1,0 +1,18 @@
+; File managed by puppet.
+;
+
+include /etc/named/named.conf.options;
+logging {
+        channel default_debug {
+                file "data/named.run";
+                severity dynamic;
+        };
+};
+zone "." IN {
+       type hint;
+       file "named.ca";
+};
+include "/etc/named.rfc1912.zones";
+include "/etc/named.root.key";
+include "/etc/named/named.conf.local";
+

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -1,6 +1,8 @@
 options {
 <% if @osfamily == 'Debian' -%>
   directory "/var/cache/bind";
+<% else -%>
+    directory "<%= @data_dir %>";
 <% end -%>
 	// If there is a firewall between you and nameservers you want
 	// to talk to, you may need to fix the firewall to allow multiple
@@ -38,7 +40,6 @@ options {
     <% end -%>};
 <% end -%>
 
-    directory "<%= @data_dir %>";
 
 <% if @listen_on_port -%>
     port <%= @listen_on_port %>;

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -1,6 +1,7 @@
 options {
-	directory "/var/cache/bind";
-
+<% if @osfamily == 'Debian' -%>
+  directory "/var/cache/bind";
+<% end -%>
 	// If there is a firewall between you and nameservers you want
 	// to talk to, you may need to fix the firewall to allow multiple
 	// ports to talk.  See http://www.kb.cert.org/vuls/id/800113
@@ -36,6 +37,8 @@ options {
       <%= ipv4_addr -%>;
     <% end -%>};
 <% end -%>
+
+    directory "<%= @data_dir %>";
 
 <% if @listen_on_port -%>
     port <%= @listen_on_port %>;
@@ -73,7 +76,12 @@ check-names response <%= @check_names_response %>;
 	// If BIND logs error messages about the root key being expired,
 	// you will need to update your keys.  See https://www.isc.org/bind-keys
 	//========================================================================
-	dnssec-validation auto;
+	dnssec-validation yes;
+        dnssec-enable yes;
+        dnssec-lookaside auto;
+        bindkeys-file "/etc/named.iscdlv.key";
+        managed-keys-directory "/var/named/dynamic";
+
 
 	auth-nxdomain no;    # conform to RFC1035
 	listen-on-v6 { any; };


### PR DESCRIPTION
Added support for controlling the content of `/etc/named` on RHEL as discussed in [issue 101](https://github.com/ajjahn/puppet-dns/issues/101)

I have tested this on CentOS 6 and I hope I have not created any regressions.