### PR TITLE
Added file_concat as a dependent module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
     concat: "git://github.com/puppetlabs/puppetlabs-concat.git"
+    file_concat: "git://github.com/electrical/puppet-lib-file_concat.git"
   symlinks:
     dns: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -30,6 +30,10 @@
       "version_requirement": ">=1.0.0 <2.0.0"
     },
     {
+      "name": "electrical/file_concat",
+      "version_requirement": ">= 1.0.1"
+    },
+    {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">=2.4.0 <6.0.0"
     }


### PR DESCRIPTION
The build started failing after I merged in #99, but it was passing when I clicked the green button.

This is because the concat module has changed since then, and our fixtures are set to always build against master.

This PR adds file_concat as a dependent module, as apparently that is a thing now:
https://github.com/puppetlabs/puppetlabs-concat#what-concat-affects


At first I thought about just pinning our fixtures to released versions, which seems like a good short term fix. However it will blind us to real breaking changes, and also means we have to manually bump it all the time to test against new versions?


I'm up for alternatives. Obviously I want the built to pass. I'm surprised that concat has an external dependency now, especially a non-puppetlabs one? But if they depend on it, then we must depend on it too (eventually).