### PR TITLE
Update dns::server::params class to not install dnssec-tools for RedHat 6

### DIFF
--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -21,7 +21,7 @@ class dns::server::params {
       $package            = 'bind'
       $service            = 'named'
       case $::operatingsystemmajrelease {
-        '7': {
+        '6', '7': {
           $necessary_packages = [ 'bind', ]
         }
         default: {


### PR DESCRIPTION
`dnssec-keygen` is included with the normal `bind` package in RedHat 6; there is no separate `dnssec-tools` package.