### PR TITLE
issue 101: take control of named.conf.

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -34,6 +34,7 @@ class dns::server::config (
     owner   => $owner,
     group   => $group,
     mode    => '0644',
+    content => template("${module_name}/named.conf.erb"),
     require => [
       File[$cfg_dir],
       Class['dns::server::install']

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -6,6 +6,9 @@ class dns::server::params {
       $cfg_dir            = '/etc/bind'
       $cfg_file           = '/etc/bind/named.conf'
       $data_dir           = '/etc/bind/zones'
+      $root_hint          = "${cfg_dir}/db.root"
+      $rfc1912_zones_cfg  = "${cfg_dir}/named.conf.default-zones"
+      $rndc_key_file      = "${cfg_dir}/ns-example-com_rndc-key"
       $group              = 'bind'
       $owner              = 'bind'
       $package            = 'bind9'
@@ -16,6 +19,9 @@ class dns::server::params {
       $cfg_dir            = '/etc/named'
       $cfg_file           = '/etc/named.conf'
       $data_dir           = '/var/named'
+      $root_hint          = "${data_dir}/named.ca"
+      $rfc1912_zones_cfg  = '/etc/named.rfc1912.zones'
+      $rndc_key_file      = '/etc/named.root.key'
       $group              = 'named'
       $owner              = 'named'
       $package            = 'bind'

--- a/spec/classes/dns__server__config_spec.rb
+++ b/spec/classes/dns__server__config_spec.rb
@@ -16,7 +16,17 @@ describe 'dns::server::config', :type => :class do
       }
     end
     it { should contain_file('/etc/bind/').with_owner('bind') }
+    it { should contain_file('/etc/bind/named.conf').with_content(/^include "\/etc\/bind\/named.conf.options";$/) }
   end
 
+  context "on a RedHat OS" do
+    let :facts do
+      {
+        :osfamily => 'RedHat'
+      }
+    end
+    it { should contain_file('/etc/named.conf').with_owner('named') }
+    it { should contain_file('/etc/named.conf').with_content(/^include "\/etc\/named\/named.conf.options";$/) }
+  end
 end
 

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -1,0 +1,18 @@
+; File managed by puppet.
+;
+
+include "<%= @cfg_dir %>/named.conf.options";
+logging {
+        channel default_debug {
+                file "data/named.run";
+                severity dynamic;
+        };
+};
+zone "." IN {
+       type hint;
+       file "<%= root_hint %>";
+};
+include "<%= @rfc1912_zones_cfg %>";
+include "<%= @rndc_key_file %>";
+include "<%= @cfg_dir %>/named.conf.local";
+

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -10,7 +10,7 @@ logging {
 };
 zone "." IN {
        type hint;
-       file "<%= root_hint %>";
+       file "<%= @root_hint %>";
 };
 include "<%= @rfc1912_zones_cfg %>";
 include "<%= @rndc_key_file %>";


### PR DESCRIPTION
This PR incorporates and fixes the changes proposed by chriscrowley
in PR https://github.com/ajjahn/puppet-dns/pull/102:

-   control content of named.conf in addition to simple presence and ownership.
    -   add to server params the additional named.conf settings that differ between Debian and RedHat
    -   use a single template for both OSes
-   add tests for RedHat and update tests for Debian to ensure that named.conf is getting created with proper ownership and content.