### PR TITLE
Add param to manage packages

### DIFF
--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -1,11 +1,12 @@
 # == Class dns::server
 #
 class dns::server::install (
-  $necessary_packages = $dns::server::params::necessary_packages
+  $necessary_packages = $dns::server::params::necessary_packages,
+  $ensure_packages    = $dns::server::params::ensure_packages,
 ) inherits dns::server::params {
 
   package { $necessary_packages :
-    ensure => latest,
+    ensure => $ensure_packages,
   }
 
 }

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -32,4 +32,5 @@ class dns::server::params {
       fail("dns::server is incompatible with this osfamily: ${::osfamily}")
     }
   }
+  $ensure_packages = latest
 }

--- a/spec/classes/dns__server__install_spec.rb
+++ b/spec/classes/dns__server__install_spec.rb
@@ -5,19 +5,50 @@ describe 'dns::server::install', :type => :class do
     it{ should raise_error(/dns::server is incompatible with this osfamily/) }
   end
 
-  context "on a Debian OS" do
+  context "on a Debian OS with default params" do
     let(:facts) {{ :osfamily => 'Debian' }}
     it { should contain_class('dns::server::params') }
     ['bind9', 'dnssec-tools'].each do |package|
-        it { should contain_package(package) }
+        it do
+          should contain_package(package).with({
+            'ensure' => 'latest',
+          })
+        end
     end
   end
 
-  context "on a RedHat OS" do
+  context "on a Debian OS with non-default params" do
+    let(:facts)  {{ :osfamily        => 'Debian'  }}
+    let(:params) {{ :ensure_packages => 'present' }}
+    it { should contain_class('dns::server::params') }
+    ['bind9', 'dnssec-tools'].each do |package|
+        it do
+          should contain_package(package).with({
+            'ensure' => 'present',
+          })
+        end
+    end
+  end
+
+  context "on a RedHat OS with default params" do
     let(:facts) {{ :osfamily => 'RedHat' }}
     it { should contain_class('dns::server::params') }
-    it { should contain_package('bind') }
+    it do 
+      should contain_package('bind').with({
+        'ensure' => 'latest',
+      })
+    end
+  end
+  
+  context "on a RedHat OS with non-default params" do
+    let(:facts)  {{ :osfamily        => 'RedHat'  }}
+    let(:params) {{ :ensure_packages => 'present' }}
+    it { should contain_class('dns::server::params') }
+    it do 
+      should contain_package('bind').with({
+        'ensure' => 'present',
+      })
+    end
   end
 
 end
-


### PR DESCRIPTION
Hi - With the environments I work with we need a bit more control of the versions of software installed and can't take the latest versions straight away. This PR is to have a parameter for the packages so that an alternative value such as 'present' can override the default value for the param. I set the default for the new param to 'latest' as that is what the module currently uses.