### PR TITLE
Fix comment syntax in named.conf template

### DIFF
--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -1,5 +1,5 @@
-; File managed by puppet.
-;
+// File managed by puppet.
+//
 
 include "<%= @cfg_dir %>/named.conf.options";
 logging {


### PR DESCRIPTION
Hi - Was unable to start the named service due to syntax error in named.conf tempate. This PR corrects the syntax on the comments.