### PR TITLE
Updated concat module version

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -42,7 +42,6 @@ define dns::key {
     owner   => $dns::server::params::owner,
     group   => $dns::server::params::group,
     mode    => '0644',
-    require => Class['concat::setup'],
     notify  => Class['dns::server::service']
   }
 

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -39,10 +39,10 @@ define dns::key {
   }
 
   concat { "${cfg_dir}/bind.keys.d/${name}.key":
-    owner   => $dns::server::params::owner,
-    group   => $dns::server::params::group,
-    mode    => '0644',
-    notify  => Class['dns::server::service']
+    owner  => $dns::server::params::owner,
+    group  => $dns::server::params::group,
+    mode   => '0644',
+    notify => Class['dns::server::service']
   }
 
   Concat::Fragment {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -43,10 +43,10 @@ class dns::server::config (
   }
 
   concat { "${cfg_dir}/named.conf.local":
-    owner   => $owner,
-    group   => $group,
-    mode    => '0644',
-    notify  => Class['dns::server::service']
+    owner  => $owner,
+    group  => $group,
+    mode   => '0644',
+    notify => Class['dns::server::service']
   }
 
   concat::fragment{'named.conf.local.header':

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -46,7 +46,6 @@ class dns::server::config (
     owner   => $owner,
     group   => $group,
     mode    => '0644',
-    require => Class['concat::setup'],
     notify  => Class['dns::server::service']
   }
 

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -58,7 +58,7 @@ define dns::zone (
       owner   => $dns::server::params::owner,
       group   => $dns::server::params::group,
       mode    => '0644',
-      require => [Class['dns::server']],
+      require => Class['dns::server'],
       notify  => Exec["bump-${zone}-serial"]
     }
     concat::fragment{"db.${name}.soa":

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -58,7 +58,7 @@ define dns::zone (
       owner   => $dns::server::params::owner,
       group   => $dns::server::params::group,
       mode    => '0644',
-      require => [Class['concat::setup'], Class['dns::server']],
+      require => [Class['dns::server']],
       notify  => Exec["bump-${zone}-serial"]
     }
     concat::fragment{"db.${name}.soa":

--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">=1.0.0 <2.0.0"
+      "version_requirement": ">=1.0.0 <3.0.0"
     },
     {
       "name": "electrical/file_concat",


### PR DESCRIPTION
The concat module is on version 2.0.0. The vast majority of changes are internal, meant to speed the module up. On first glance there do not appear to be any changes which would cause this module issue.