### PR TITLE
Fixes #93 - Avoid the extra dot in the soa

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -1,7 +1,7 @@
 # == Define dns::zone
 #
 define dns::zone (
-  $soa = "${::fqdn}",
+  $soa = ${::fqdn},
   $soa_email = "root.${::fqdn}",
   $zone_ttl = '604800',
   $zone_refresh = '604800',

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -1,8 +1,8 @@
 # == Define dns::zone
 #
 define dns::zone (
-  $soa = "${::fqdn}.",
-  $soa_email = "root.${::fqdn}.",
+  $soa = "${::fqdn}",
+  $soa_email = "root.${::fqdn}",
   $zone_ttl = '604800',
   $zone_refresh = '604800',
   $zone_retry = '86400',

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -1,7 +1,7 @@
 # == Define dns::zone
 #
 define dns::zone (
-  $soa = ${::fqdn},
+  $soa = $::fqdn,
   $soa_email = "root.${::fqdn}",
   $zone_ttl = '604800',
   $zone_refresh = '604800',


### PR DESCRIPTION
There was extra dot in the $soa and $soa_email definition. The consequence was an extra dot in the zones/db.xxx file.