### PR TITLE
Fix non-existent directory and substitute by a param variable.

### DIFF
--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -1,5 +1,5 @@
 options {
-	directory "/var/cache/bind";
+	directory "<%= scope.lookupvar('::dns::server::params::data_dir') %>";
 
 	// If there is a firewall between you and nameservers you want
 	// to talk to, you may need to fix the firewall to allow multiple


### PR DESCRIPTION
CentOS 7 reports ...

May 19 00:20:41 server3 named-checkconf[463]: /etc/named/named.conf.options:2: parsing failed
May 19 00:20:41 server3 named-checkconf[463]: /etc/named/named.conf.options:2: change directory to '/var/cache/bind' failed: file not found
