### PR TITLE
Named.options fix

### DIFF
--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -8,7 +8,7 @@ class dns::server::params {
       $data_dir           = '/etc/bind/zones'
       $root_hint          = "${cfg_dir}/db.root"
       $rfc1912_zones_cfg  = "${cfg_dir}/named.conf.default-zones"
-      $rndc_key_file      = "${cfg_dir}/ns-example-com_rndc-key"
+      $rndc_key_file      = "${cfg_dir}/rndc.key"
       $group              = 'bind'
       $owner              = 'bind'
       $package            = 'bind9'

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -8,11 +8,6 @@ logging {
                 severity dynamic;
         };
 };
-zone "." IN {
-       type hint;
-       file "<%= @root_hint %>";
-};
 include "<%= @rfc1912_zones_cfg %>";
 include "<%= @rndc_key_file %>";
 include "<%= @cfg_dir %>/named.conf.local";
-


### PR DESCRIPTION
Three major big fixes which were introduced to the "named.conf" file in #112 - 

* Corrected the location of the rndc.key file on debian.
* Removed the extra definition of the "." zone.
* Removed the "logging" setup, which referred to a nonexistent file.

All three of these errors will prevent bind from starting up.

This should resolve #115.