### PR TITLE
Correct path for named.conf.options in tests/init.pp

### DIFF
--- a/tests/init.pp
+++ b/tests/init.pp
@@ -2,7 +2,7 @@
 
 include dns::server
 
-dns::server::options { '/etc/bind/named.conf.options':
+dns::server::options { "${dns::server::params::cfg_dir}/named.conf.options":
   forwarders => [ '8.8.8.8', '8.8.4.4' ]
 }
 


### PR DESCRIPTION
The tests/init.pp smoketest hardcoded the /etc/bind directory; this changes it to use ${dns::server::params::cfg_dir} instead so the smoketest will be valid on RedHat family systems.