### PR TITLE
fix zone template's @allow_transfer check

### DIFF
--- a/templates/zone.erb
+++ b/templates/zone.erb
@@ -16,7 +16,7 @@ type <%= @zone_type %>;
 <% if @zone_type == 'slave' -%>
     masters { <%= @slave_masters %>;};
 <% elsif @zone_type == 'master' -%>
-    <% if @allow_transfer -%>
+    <% if @allow_transfer.is_a?(Array) and @allow_transfer.size != 0 -%>
         allow-transfer {
         <% @allow_transfer.each do |ip| -%>
             <%= ip %>;


### PR DESCRIPTION
the zone template was including empty allow_transfer {} blocks because
a 0-length array was still being treated as "true".  this PR changes
the check to verify that @allow_transfer is an array and has >0 size.