### PR TITLE
Make dnssec validation a configurable option.

### DIFF
--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -75,6 +75,7 @@
 #    forwarders => [ '8.8.8.8', '8.8.4.4' ],
 #   }
 #
+include dns::server::params
 define dns::server::options (
   $forwarders = [],
   $transfers = [],
@@ -89,7 +90,7 @@ define dns::server::options (
   $statistic_channel_port = undef,
   $zone_notify = undef,
   $also_notify = [],
-  $dnssec_validation = undef,
+  $dnssec_validation = $dns::server::params::default_dnssec_validation,
 ) {
   $valid_check_names = ['fail', 'warn', 'ignore']
   $cfg_dir = $::dns::server::params::cfg_dir
@@ -130,14 +131,6 @@ define dns::server::options (
   $valid_dnssec_validation = ['yes', 'no', 'auto', 'absent']
   if $dnssec_validation != undef and !member($valid_dnssec_validation, $dnssec_validation) {
     fail("The dnssec_validation must be ${valid_dnssec_validation}")
-  }
-
-  if $dnssec_validation != undef {
-    $real_dnssec_validation = $dnssec_validation
-  } elsif $::osfamily == 'RedHat' and $::operatingsystemmajrelease == 5 {
-    $real_dnssec_validation = 'absent'
-  } else {
-    $real_dnssec_validation = 'auto'
   }
 
   file { $title:

--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -63,11 +63,10 @@
 #   Default: empty, meaning no additional servers
 #
 # [*dnssec_validation*]
-#   Controls DNS-SEC validation.  String of "yes", "auto", "no", or
-#   "absent" (to prevent the `dnssec-validation` option from being
-#   included).  Default is "absent" on RedHat 5 (whose default bind
-#   package is too old to include dnssec validation), and "auto" on
-#   Debian and on RedHat 6 and above.
+#   Controls DNS-SEC validation.  String of "yes", "no", or "auto".
+#   If set to `undef`, the dnssec_validation option will be omitted.
+#   Default is `undef` on RedHat 5, and "auto" on Debian and on
+#   RedHat 6 and above.
 #
 # === Examples
 #
@@ -128,7 +127,7 @@ define dns::server::options (
     fail("The zone_notify must be ${valid_zone_notify}")
   }
 
-  $valid_dnssec_validation = ['yes', 'no', 'auto', 'absent']
+  $valid_dnssec_validation = ['yes', 'no', 'auto']
   if $dnssec_validation != undef and !member($valid_dnssec_validation, $dnssec_validation) {
     fail("The dnssec_validation must be ${valid_dnssec_validation}")
   }

--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -63,10 +63,11 @@
 #   Default: empty, meaning no additional servers
 #
 # [*dnssec_validation*]
-#   Controls DNS-SEC validation.  String of "yes", "no", or "auto".
-#   If set to `undef`, the dnssec_validation option will be omitted.
-#   Default is `undef` on RedHat 5, and "auto" on Debian and on
-#   RedHat 6 and above.
+#   Controls DNS-SEC validation.  String of "yes", "auto", "no", or
+#   "absent" (to prevent the `dnssec-validation` option from being
+#   included).  Default is "absent" on RedHat 5 (whose default bind
+#   package is too old to include dnssec validation), and "auto" on
+#   Debian and on RedHat 6 and above.
 #
 # === Examples
 #
@@ -127,7 +128,7 @@ define dns::server::options (
     fail("The zone_notify must be ${valid_zone_notify}")
   }
 
-  $valid_dnssec_validation = ['yes', 'no', 'auto']
+  $valid_dnssec_validation = ['yes', 'no', 'auto', 'absent']
   if $dnssec_validation != undef and !member($valid_dnssec_validation, $dnssec_validation) {
     fail("The dnssec_validation must be ${valid_dnssec_validation}")
   }

--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -62,6 +62,13 @@
 #   should be sent.
 #   Default: empty, meaning no additional servers
 #
+# [*dnssec_validation*]
+#   Controls DNS-SEC validation.  String of "yes", "auto", "no", or
+#   "absent" (to prevent the `dnssec-validation` option from being
+#   included).  Default is "absent" on RedHat 5 (whose default bind
+#   package is too old to include dnssec validation), and "auto" on
+#   Debian and on RedHat 6 and above.
+#
 # === Examples
 #
 #  dns::server::options { '/etc/bind/named.conf.options':
@@ -82,6 +89,7 @@ define dns::server::options (
   $statistic_channel_port = undef,
   $zone_notify = undef,
   $also_notify = [],
+  $dnssec_validation = undef,
 ) {
   $valid_check_names = ['fail', 'warn', 'ignore']
   $cfg_dir = $::dns::server::params::cfg_dir
@@ -117,6 +125,19 @@ define dns::server::options (
   $valid_zone_notify = ['yes', 'no', 'explicit', 'master-only']
   if $zone_notify != undef and !member($valid_zone_notify, $zone_notify) {
     fail("The zone_notify must be ${valid_zone_notify}")
+  }
+
+  $valid_dnssec_validation = ['yes', 'no', 'auto', 'absent']
+  if $dnssec_validation != undef and !member($valid_dnssec_validation, $dnssec_validation) {
+    fail("The dnssec_validation must be ${valid_dnssec_validation}")
+  }
+
+  if $dnssec_validation != undef {
+    $real_dnssec_validation = $dnssec_validation
+  } elsif $::osfamily == 'RedHat' and $::operatingsystemmajrelease == 5 {
+    $real_dnssec_validation = 'absent'
+  } else {
+    $real_dnssec_validation = 'auto'
   }
 
   file { $title:

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -28,7 +28,7 @@ class dns::server::params {
       $package            = 'bind'
       $service            = 'named'
       $necessary_packages = [ 'bind', ]
-      if $operatingsystemmajrelease < 6 {
+      if $::operatingsystemmajrelease =~ /^[1-5]$/ {
         $default_dnssec_validation = 'absent'
       } else {
         $default_dnssec_validation = 'auto'

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -14,6 +14,7 @@ class dns::server::params {
       $package            = 'bind9'
       $service            = 'bind9'
       $necessary_packages = [ 'bind9', 'dnssec-tools' ]
+      $default_dnssec_validation = 'auto'
     }
     'RedHat': {
       $cfg_dir            = '/etc/named'
@@ -27,6 +28,11 @@ class dns::server::params {
       $package            = 'bind'
       $service            = 'named'
       $necessary_packages = [ 'bind', ]
+      if $operatingsystemmajrelease < 6 {
+        $default_dnssec_validation = 'absent'
+      } else {
+        $default_dnssec_validation = 'auto'
+      }
     }
     default: {
       fail("dns::server is incompatible with this osfamily: ${::osfamily}")

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -29,7 +29,7 @@ class dns::server::params {
       $service            = 'named'
       $necessary_packages = [ 'bind', ]
       if $::operatingsystemmajrelease =~ /^[1-5]$/ {
-        $default_dnssec_validation = undef
+        $default_dnssec_validation = 'absent'
       } else {
         $default_dnssec_validation = 'auto'
       }

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -29,7 +29,7 @@ class dns::server::params {
       $service            = 'named'
       $necessary_packages = [ 'bind', ]
       if $::operatingsystemmajrelease =~ /^[1-5]$/ {
-        $default_dnssec_validation = 'absent'
+        $default_dnssec_validation = undef
       } else {
         $default_dnssec_validation = 'auto'
       }

--- a/spec/defines/dns__server__options_spec.rb
+++ b/spec/defines/dns__server__options_spec.rb
@@ -220,5 +220,54 @@ describe 'dns::server::options', :type => :define do
     it { should contain_file('/etc/bind/named.conf.options').with_content(/8\.8\.8\.8;/) }
   end
 
+  context 'default value of dnssec_validation on RedHat 5' do
+    let :facts do
+      { :osfamily => 'RedHat', :operatingsystemmajrelease => '5' }
+    end
+    it { should contain_file('/etc/bind/named.conf.options').without_content(/dnssec-validation/) }
+  end
+
+  context 'default value of dnssec_validation on RedHat 6' do
+    let :facts do
+      { :osfamily => 'RedHat', :operatingsystemmajrelease => '6' }
+    end
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-validation auto/) }
+  end
+
+  context 'default value of dnssec_validation on Debian' do
+    let :facts do
+      { :osfamily => 'Debian' }
+    end
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-validation auto/) }
+  end
+
+  context 'passing `absent` to dnssec_validation' do
+    let :params do
+      { :dnssec_validation => 'absent' }
+    end
+    it { should contain_file('/etc/bind/named.conf.options').without_content(/dnssec-validation/) }
+  end
+
+  context 'passing `auto` to dnssec_validation' do
+    let :params do
+      { :dnssec_validation => 'auto' }
+    end
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-validation auto/) }
+  end
+
+  context 'passing `yes` to dnssec_validation' do
+    let :params do
+      { :dnssec_validation => 'yes' }
+    end
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-validation yes/) }
+  end
+
+  context 'passing `no` to dnssec_validation' do
+    let :params do
+      { :dnssec_validation => 'no' }
+    end
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-validation no/) }
+  end
+
 end
 

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -90,8 +90,8 @@ also-notify {
 	// If BIND logs error messages about the root key being expired,
 	// you will need to update your keys.  See https://www.isc.org/bind-keys
 	//========================================================================
-<% if @real_dnssec_validation != 'absent' -%>
-	dnssec-validation <%= @real_dnssec_validation %>;
+<% if @dnssec_validation != 'absent' -%>
+	dnssec-validation <%= @dnssec_validation %>;
 <% end -%>
 
 	auth-nxdomain no;    # conform to RFC1035

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -90,7 +90,7 @@ also-notify {
 	// If BIND logs error messages about the root key being expired,
 	// you will need to update your keys.  See https://www.isc.org/bind-keys
 	//========================================================================
-<% if @dnssec_validation != 'absent' -%>
+<% if @dnssec_validation -%>
 	dnssec-validation <%= @dnssec_validation %>;
 <% end -%>
 

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -90,7 +90,9 @@ also-notify {
 	// If BIND logs error messages about the root key being expired,
 	// you will need to update your keys.  See https://www.isc.org/bind-keys
 	//========================================================================
-	dnssec-validation auto;
+<% if @real_dnssec_validation != 'absent' -%>
+	dnssec-validation <%= @real_dnssec_validation %>;
+<% end -%>
 
 	auth-nxdomain no;    # conform to RFC1035
 	listen-on-v6 { any; };

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -90,7 +90,7 @@ also-notify {
 	// If BIND logs error messages about the root key being expired,
 	// you will need to update your keys.  See https://www.isc.org/bind-keys
 	//========================================================================
-<% if @dnssec_validation -%>
+<% if @dnssec_validation != 'absent' -%>
 	dnssec-validation <%= @dnssec_validation %>;
 <% end -%>
 


### PR DESCRIPTION
Default it to "absent" on RedHat 5 whose default bind package is too old for dnssec.