### PR TITLE
Fix the `directory` option in named.conf.options

### DIFF
--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -85,6 +85,7 @@ define dns::server::options (
 ) {
   $valid_check_names = ['fail', 'warn', 'ignore']
   $cfg_dir = $::dns::server::params::cfg_dir
+  $data_dir = $::dns::server::params::data_dir
 
   if ! defined(Class['::dns::server']) {
     fail('You must include the ::dns::server base class before using any dns options defined resources')

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -1,5 +1,5 @@
 options {
-	directory "/var/cache/bind";
+	directory "<%= @data_dir %>";
 
 	// If there is a firewall between you and nameservers you want
 	// to talk to, you may need to fix the firewall to allow multiple


### PR DESCRIPTION
Instead of hardcoding it to point to /var/cache/named (which does not exist on RedHat), use dns::server::params::data_dir instead.