### PR TITLE
Add Gemfile.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pkg
 .vagrant
 /.project
 log/
+Gemfile.lock


### PR DESCRIPTION
I noticed that the `Gemfile.lock` file was removed during a recent update.  Since this file apparently gets recreated when needed, and (from experience) it might be different depending on the version of bundler and other tools in use, I'm suggesting adding it to the `.gitignore` file.