### PR TITLE
feature TSIG configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ node 'server.example.com' {
     zone => 'example.com',
     data => 'Hello World',
   }
+
+  # TSIG
+  dns::tsig { 'ns3' :
+    ensure    => present,
+    algorithm => "hmac-md5",
+    secret    => "La/E5CjG9O+os1jq0a2jdA==",
+    server    => "192.168.1.3"
+  }
+
 }
 ```
 

--- a/manifests/tsig.pp
+++ b/manifests/tsig.pp
@@ -1,0 +1,37 @@
+# defined type allows you to declare a BIND TSIG.
+#
+# Parameters:
+#
+# $ensure = ensure the persence or absence of the acl.
+# $keyname = the name given to the TSIG KEY. This must be unique. This defaults to
+#   the namevar.
+# $algorithm = Defined algorithm of the key (default: hmac-md5)
+# $server = related string or array of ip addresses to this key
+# $secret = shared secret of the key
+#
+# Usage:
+#
+# dns::tsig { 'ns3':
+#   ensure => present,
+#   algorithm => "hmac-md5"
+#   secret    => "dTIxGBPjkT/8b6BYHTUA=="
+# }
+#
+define dns::tsig (
+  $keyname   = $name,
+  $algorithm = 'hmac-md5',
+  $server    = undef,
+  $secret    = undef,
+  $ensure    = present
+) {
+
+  validate_string($name)
+
+  concat::fragment { "named.conf.local.tsig.${name}.include":
+    ensure  => $ensure,
+    target  => '/etc/bind/named.conf.local',
+    order   => 4,
+    content => template("${module_name}/tsig.erb"),
+  }
+
+}

--- a/spec/defines/dns__tsig_spec.rb
+++ b/spec/defines/dns__tsig_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'dns::tsig' do
+  let(:facts) {{ :osfamily => 'Debian', :concat_basedir => '/mock_dir' }}
+  let(:title) { 'ns3' }
+  let :pre_condition do
+    'class { "::dns::server::config": }'
+  end
+
+  context 'passing valid array to server' do
+    let :params do
+      { :server => [ '192.168.0.1', '192.168.0.2' ],
+        :algorithm => 'hmac-md5',
+        :secret => 'La/E5CjG9O+os1jq0a2jdA==' }
+    end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('named.conf.local.tsig.ns3.include') }
+    it { should contain_concat__fragment('named.conf.local.tsig.ns3.include').with_content(/key ns3\. \{/)  }
+    it { should contain_concat__fragment('named.conf.local.tsig.ns3.include').with_content(/server 192\.168\.0\.1/)  }
+    it { should contain_concat__fragment('named.conf.local.tsig.ns3.include').with_content(/server 192\.168\.0\.2/)  }
+  end
+
+  context 'passing valid string to server' do
+    let :params do
+      { :server => '192.168.0.1', 
+        :algorithm => 'hmac-md5',
+        :secret => 'La/E5CjG9O+os1jq0a2jdA==' }
+    end
+    it { should_not raise_error }
+
+    it { should contain_concat__fragment('named.conf.local.tsig.ns3.include') }
+    it { should contain_concat__fragment('named.conf.local.tsig.ns3.include').with_content(/key ns3\. \{/)  }
+    it { should contain_concat__fragment('named.conf.local.tsig.ns3.include').with_content(/server 192\.168\.0\.1/)  }
+  end
+
+end
+

--- a/templates/tsig.erb
+++ b/templates/tsig.erb
@@ -2,8 +2,8 @@ key <%= @keyname %>. {
   algorithm <%= @algorithm %>;
   secret "<%= @secret %>";
 };
-<% if server.class == Array -%>
-<% server.each do |host| -%>
+<% if @server.class == Array -%>
+<% @server.each do |host| -%>
 server <%= host -%> {
   keys { <%= @keyname %>. ; };
 };

--- a/templates/tsig.erb
+++ b/templates/tsig.erb
@@ -1,0 +1,17 @@
+key <%= @keyname %>. {
+  algorithm <%= @algorithm %>;
+  secret "<%= @secret %>";
+};
+<% if server.class == Array -%>
+<% server.each do |host| -%>
+server <%= host -%> {
+  keys { <%= @keyname %>. ; };
+};
+<% end -%>
+<% else -%>
+<% if @server then -%>
+server <%= @server %> {
+  keys { <%= @keyname %>. ; };
+};
+<% end -%>
+<% end -%>


### PR DESCRIPTION
To exchange DNS zones between two bind installations like master/slave you can sign this transaction with a key. It's more secure as IP-based zone transfer and protect against spoofing (see ftp://ftp.isc.org/isc/bind/9.8.0-P4/doc/arm/Bv9ARM.ch04.html#tsig)
