### PR TITLE
params.pp: excluded dnssec-tools from $necessary_package for debian 8

### DIFF
--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -13,8 +13,15 @@ class dns::server::params {
       $owner              = 'bind'
       $package            = 'bind9'
       $service            = 'bind9'
-      $necessary_packages = [ 'bind9', 'dnssec-tools' ]
       $default_dnssec_validation = 'auto'
+      case $::operatingsystemmajrelease {
+        '8': {
+          $necessary_packages = ['bind9']
+        }
+        default: {
+          $necessary_packages = [ 'bind9', 'dnssec-tools' ]
+        }
+      }
     }
     'RedHat': {
       $cfg_dir            = '/etc/named'


### PR DESCRIPTION
hi i have excluded dnssec-tools for debian 8, there is no package in official repository for jessie.