### PR TITLE
Move stats Channels

### DIFF
--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -1,3 +1,8 @@
+<% if @statistic_channel_ip and @statistic_channel_port -%>
+statistics-channels {
+    inet <%= @statistic_channel_ip %> port <%= @statistic_channel_port %>;
+};
+<% end -%>
 options {
 	directory "<%= @data_dir %>";
 
@@ -69,11 +74,7 @@ check-names slave <%= @check_names_slave %>;
 check-names response <%= @check_names_response %>;
 <% end -%>
 
-<% if @statistic_channel_ip and @statistic_channel_port -%>
-statistics-channels {
-    inet <%= @statistic_channel_ip %> port <%= @statistic_channel_port %>;
-};
-<% end -%>
+
 
 <% if @zone_notify -%>
 notify <%= @zone_notify %>;


### PR DESCRIPTION
Prior to this commit the stats channels was inside options which caused bind to not start
Moving this allowed the daemon to start and verified it was a working configuration as well.

```
2015-07-23T22:56:15.854601-04:00 hank named[4311]: /etc/bind/named.conf.options:29: unknown option 'statistics-channels'
```