### PR TITLE
Allow the dns::zone::slave_masters parameter to be an array

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -1,5 +1,136 @@
 # == Define dns::zone
 #
+# `dns::zone` defines a DNS zone and creates both the zone entry
+# in the `named.conf` files and the standardized zone file header
+# to which the zone records will be added.
+#
+# === BIND Time Values
+#
+# BIND time values are numeric strings and default to representing a
+# number of seconds (e.g. a time value of `3600` equals one hour).
+# Time values may optionally be followed by a suffix of `m`, `h`,
+# `d`, or `w`, meaning the time is in minutes, hours, days, or weeks,
+# respectively.  For example, one week could be represented as any of
+# `1w`, `7d`, `168h`, `10080m`, or `604800`.
+#
+# === FQDN Values
+#
+# The `dns::zone` type will append the final `.` dot to any value which
+# is listed in the *Parameters* section as an *FQDN* (Fully Qualified
+# Domain Name).  This has two implications:  First, any FQDN must *not*
+# include the trailing `.` dot; second, any parameter listed as an FQDN
+# _must_ be fully-qualified, and will not allow the hostname-only form
+# of the name (e.g. in the `example.net` domain, `ns1.example.net` could
+# not be referred to as `ns1` in any parameter that requires an FQDN).
+#
+# === Access Control Lists
+#
+# Any parameter which is an Access Control List is an array that may
+# contain the pre-defined ACL names `none`, `any`, `localhost`, or
+# `localnets`, or may contain ip addresses, optionally precededed by a
+# `!` exclamation mark and optionally followed by a `/` and a prefix
+# length for a subnet match.
+#
+# === Parameters
+#
+# [*allow_transfer*]
+#   An array that indicates what other DNS servers may initiate a
+#   zone transfer of this zone.  The array may contain IP addresses,
+#   optionally followed by a `/` and a prefix length for a subnet match,
+#   and optionally prefixed by a `!` exclamation mark (to indicate that
+#   the IP address - or addresses, with a subnet match - are denied
+#   rather than allowed) or the special ACL names `any`, `localhost`,
+#   `localnets`, or `none`: `any` matches any host; `localhost` matches
+#   only the name server itself; `localnets` matches the name server
+#   and any request from the name server's subnet(s); and `none` is the
+#   equivalent of `!any` - it denies all requests.  The first entry in
+#   the array that matches the requester's address will be used.
+#
+# [*allow_forwarder*]
+#   An array of IP addresses and optional port numbers to which queries
+#   for this zone will be forwarded (based on the *forward_policy*
+#   setting).  If the optional port number is included, it must be
+#   separated from the IP address by the word `port` - for example, `[
+#   '192.168.100.102 port 1234' ]`.  Defaults to an empty array, which
+#   means no forwarding will be done.
+#
+# [*also_notify*]
+#   This is an array of IP addresses and optional port numbers to
+#   which this DNS server will send notifies when the master DNS server
+#   reloads the zone file.  See the *allow_forwarder* parameter for how
+#   to include the optional port numbers.
+#
+# [*forward_policy*]
+#   Either `first` or `only`.  If the *allow_forwarder* array is not
+#   empty, this setting defines how query forwarding is handled.  With a
+#   value of `only`, the DNS server will forward the request and return
+#   the response to the client immediately.  With a value of `first`,
+#   the DNS server will forward the request; if the forwarder server
+#   returns a not-found response, the DNS server will attempt to answer
+#   the request itself.
+#
+# [*nameservers*]
+#   An array containing the FQDN's of each name server for this zone.
+#   This will be used to create the `NS` records for the zone file.
+#   Defaults to an array containing the `$::fqdn` fact.
+#
+# [*reverse*]
+#   If `true`, the zone will have `.in-addr.arpa` appended to it.
+#   Defaults to `false`.
+#
+# [*slave_masters*]
+#   If *zone_type* is set to `slave`, this holds an array or string
+#   containing the IP addresses of the DNS servers from which this slave
+#   transfers the zone.  If a string, the IP addresses must be separated
+#   by semicolons (`;`).
+#
+# [*soa*]
+#   The authoritative name server for this zone.  Defaults to the
+#   `$::fqdn` fact.
+#
+# [*soa_email*]
+#   The point-of-contact authoritative name server for this zone, in
+#   the form _<username>_`.`_<domainname>_ (_<username>_ may not contain
+#   `.` dots).  Defaults to `root.` followed by the `$::fqdn` fact.
+#
+# [*zone_expire*]
+#   This is the maximum amount of time after the last successful refresh
+#   of the zone for which the slave will continue to respond to DNS
+#   queries for records in this zone.
+#
+# [*zone_minimum*]
+#   Despite _minimum_ in the parameter name, this is the maximum time
+#   that a _negative_ for this zone (e.g. a host not found response)
+#   may be cached by other resolvers.
+#
+# [*zone_notify*]
+#   One of `yes`, `no`, or `explicit`.   With a value of `explicit`,
+#   when sending notifies, the DNS server will send them only to the
+#   slaves listed in the `also_notify` list.  With `yes`, the DNS server
+#   will send notifies to the `also_notify` list _and_ to all nameservers
+#   listed in the `NS` records for the zone _except_ for the nameserver
+#   listed in the `soa` parameter and the sending name server.  With `no`,
+#   the DNS server will never send notifies for this zone.
+#
+# [*zone_refresh*]
+#   The minimum time between when slaves will check back with the zone
+#   master(s) to check if the zone has been updated.  See *Time values*
+#   above.  Defaults to 604800 seconds (7 days).
+#
+# [*zone_retry*]
+#   If a slave tries and fails to contact the master(s), this is the
+#   time the slave will wait before retrying.
+#
+# [*zone_ttl*]
+#   The default TTL (time-to-live) for the zone records.  See *Time
+#   values* above.  Defaults to 604800 seconds (7 days).
+#
+# [*zone_type*]
+#   The type of DNS zone being described.  Can be one of `master`, `slave`
+#   (requires *slave_masters* to be set), or `forward` (requires both
+#   *allow_forwarder* and *forward_policy* to be set).  Defaults to
+#   `master`.
+#
 define dns::zone (
   $soa = $::fqdn,
   $soa_email = "root.${::fqdn}",

--- a/spec/defines/dns__zone_spec.rb
+++ b/spec/defines/dns__zone_spec.rb
@@ -127,7 +127,7 @@ describe 'dns::zone' do
       end
       it 'should have masters entry' do
           should contain_concat__fragment('named.conf.local.test.com.include').
-                         with_content(/masters/)
+                         with_content(/masters.*123.123.123.123 *;/)
       end
       it 'should not have allow_tranfer entry' do
           should_not contain_concat__fragment('named.conf.local.test.com.include').
@@ -141,6 +141,18 @@ describe 'dns::zone' do
           should contain_concat('/etc/bind/zones/db.test.com.stage').with({
               :ensure => "absent"
           })
+      end
+  end
+
+  context 'with a slave zone with multiple masters' do
+      let :params do
+          { :slave_masters => ['123.123.123.123', '234.234.234.234'],
+            :zone_type => 'slave'
+          }
+      end
+      it 'should have masters entry with all masters joined by ;' do
+          should contain_concat__fragment('named.conf.local.test.com.include').
+                         with_content(/masters.*123.123.123.123 *;[ \n]*234.234.234.234 *;/)
       end
   end
 

--- a/templates/zone.erb
+++ b/templates/zone.erb
@@ -14,7 +14,11 @@ type <%= @zone_type %>;
     file "<%= @zone_file %>";
 <% end -%>
 <% if @zone_type == 'slave' -%>
+<%- if @slave_masters.is_a?(Array) -%>
+    masters { <%= @slave_masters.join(";") %>;};
+<%- else -%>
     masters { <%= @slave_masters %>;};
+<%- end -%>
 <% elsif @zone_type == 'master' -%>
     <% if @allow_transfer.is_a?(Array) and @allow_transfer.size != 0 -%>
         allow-transfer {


### PR DESCRIPTION
This just changes the `zone.erb` template to allow the `@slave_masters` parameter to be an array, in which case it gets joined by `";"` semicolons; if it's not an array, it's interpolated directly, just like the previous behavior.