### PR TITLE
Make "listen-on-v6" a configurable option

### DIFF
--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -13,6 +13,9 @@
 # [*listen_on*]
 #   Array of IP addresses on which to listen. Default: empty, meaning "any"
 #
+# [*listen_on_ipv6*]
+#   Array of IPv6 addresses on which to listen. Default: empty, meaning "any"
+#
 # [*listen_on_port*]:
 #   UDP/TCP port number to use for receiving and sending traffic.
 #   Default: undefined, meaning 53
@@ -80,6 +83,7 @@ define dns::server::options (
   $forwarders = [],
   $transfers = [],
   $listen_on = [],
+  $listen_on_ipv6 = [],
   $listen_on_port = undef,
   $allow_recursion = [],
   $check_names_master = undef,
@@ -103,6 +107,7 @@ define dns::server::options (
   validate_array($forwarders)
   validate_array($transfers)
   validate_array($listen_on)
+  validate_array($listen_on_ipv6)
   validate_array($allow_recursion)
   if $check_names_master != undef and !member($valid_check_names, $check_names_master) {
     fail("The check name policy check_names_master must be ${valid_check_names}")

--- a/spec/defines/dns__server__options_spec.rb
+++ b/spec/defines/dns__server__options_spec.rb
@@ -70,6 +70,26 @@ describe 'dns::server::options', :type => :define do
     it { should raise_error(Puppet::Error, /is not an Array/) }
   end
 
+  context 'when passing valid array to listen_on_ipv6' do
+    let :params do
+      { :listen_on_ipv6 => [ '2001:db8:1::1', '2001:db8:2::/124' ] }
+    end
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/2001:db8:1::1;$/)  }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/2001:db8:2::\/124;$/)  }
+  end
+
+  context 'when passing a string to listen_on_ipv6' do
+    let :params do
+      { :listen_on_ipv6 => '2001:db8:1::1' }
+    end
+    it { should raise_error(Puppet::Error, /is not an Array/) }
+  end
+
+  context 'when the listen_on_ipv6 option is not provided' do
+    let(:params) { {} }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/listen-on-v6 {.+?any;.+?}/) }
+  end
+
   context 'passing a string to recursion' do
     let :params do
       { :allow_recursion => '8.8.8.8' }

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -37,6 +37,15 @@ options {
     <% end -%>};
 <% end -%>
 
+<% if @listen_on_ipv6.empty? then -%>
+    listen-on-v6 { any; };
+<% else -%>
+    listen-on-v6 {
+    <% @listen_on_ipv6.each do |ipv6_addr| -%>
+      <%= ipv6_addr -%>;
+    <% end -%>};
+<% end -%>
+
 <% if @listen_on_port -%>
     port <%= @listen_on_port %>;
 <% end -%>
@@ -95,5 +104,4 @@ also-notify {
 <% end -%>
 
 	auth-nxdomain no;    # conform to RFC1035
-	listen-on-v6 { any; };
 };


### PR DESCRIPTION
Previously, the "listen-on-v6" option was hard-coded to the value "any" which limited IPv6 configurability.

This commit adds dns::server::options::listen_on_ipv6, allowing an array of values to be provided for the config option.