### PR TITLE
fixes for puppet future parser support

### DIFF
--- a/manifests/server/default.pp
+++ b/manifests/server/default.pp
@@ -18,11 +18,11 @@ class dns::server::default (
 
   validate_absolute_path( $default_file )
 
-  if $resolvconf != '' {
+  if $resolvconf {
     validate_re( $resolvconf, '^(yes|no)$', 'The resolvconf value is not type of a string yes / no.' )
   }
 
-  if $rootdir != '' {
+  if $rootdir {
     validate_absolute_path( $rootdir )
   }
 
@@ -30,7 +30,7 @@ class dns::server::default (
 
   validate_re( $enable_sdb, '^(yes|no|1|0|\s*)$', 'The enable_sdb value is not type of a string yes / no / 1 / 0 or empty.' )
 
-  if $keytab_file != '' {
+  if $keytab_file {
     validate_absolute_path( $keytab_file )
   }
 


### PR DESCRIPTION
When using puppet future parser, this module does not work when e.g. resolvconf is not set (read: undef).
```
Error: The resolvconf value is not type of a string yes / no. on node example.xyz
```

This PR fixes this. Maybe you should have travis test Puppet 4 and future parser as well. But I think, this is out of scope of this PR.