### PR TITLE
fix variable access preference with @preference

### DIFF
--- a/templates/zone_record.erb
+++ b/templates/zone_record.erb
@@ -4,5 +4,5 @@ data_a = @data.is_a?(String) ? @data.lines.to_a : @data
 
 data_a.each do |data_item| 
 -%>
-<%= @host %>	<%= @ttl %>	<%= @dns_class %>	<%= @record.upcase %><%= @record.upcase == 'MX' ? " #{preference}" : '' %>	<%= delimiter %><%= data_item %><%= delimiter %>
+<%= @host %>	<%= @ttl %>	<%= @dns_class %>	<%= @record.upcase %><%= @record.upcase == 'MX' ? " #{@preference}" : '' %>	<%= delimiter %><%= data_item %><%= delimiter %>
 <% end -%>


### PR DESCRIPTION
This PR fixes the warning:

```
Warning: Variable access via 'preference' is deprecated. Use '@preference' instead. template[/path/to/puppet/modules/dns/templates/zone_record.erb]:7
   (at /usr/lib/ruby/vendor_ruby/puppet/parser/templatewrapper.rb:76:in `method_missing')
```
