### PR TITLE
Add `all_ptr` parameter to `dns::record::a` record type

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,3 +7,85 @@ class dns {
   # include dns::config
   # include dns::service
 }
+
+# == Definition: dns_reverse_ptr_record
+#
+# This is a private type defined to allow the dns::record::a
+# defined resource type to create reverse ptr records for hosts
+# with multiple ip addresses.
+#
+# === Parameters
+#
+# * `$ip`
+# The ip address for the ptr record.  Defaults to the resource title.
+#
+# * `$host`
+# The (unqualified) host pointed to by this ptr record.
+#
+# * `$zone`
+# The domain of the host pointed to by this ptr record.
+#
+# === Actions
+#
+# Reformats the $ip, $host, $zone parameters to create a `dns::record::ptr` 
+# resource
+#
+# === Examples
+#
+# @example
+#     dns_reverse_ptr_record { '192.168.128.42':
+#       host => 'server' ,
+#       zone => 'example.com' ,
+#     }
+#
+# turns into:
+#
+# @example
+#     dns::record::ptr { '42.128.168.192.IN-ADDR.ARPA':
+#       host => '42' ,
+#       zone => '128.168.192.IN-ADDR.ARPA' ,
+#       data => 'server.example.com' ,
+#     }
+#
+# ---
+# @example
+#     dns_reverse_ptr_record { [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ]:
+#       host => 'multihomed-server' ,
+#       zone => 'example.com' ,
+#     }
+#
+# turns into:
+#
+# @example
+#     dns::record::ptr { '68.128.168.192.IN-ADDR.ARPA':
+#       host => '68' ,
+#       zone => '128.168.192.IN-ADDR.ARPA' ,
+#       data => 'multihomed-server.example.com' ,
+#
+# @example
+#     dns::record::ptr { '69.128.168.192.IN-ADDR.ARPA':
+#       host => '69' ,
+#       zone => '128.168.192.IN-ADDR.ARPA' ,
+#       data => 'multihomed-server.example.com' ,
+#
+# @example
+#     dns::record::ptr { '70.128.168.192.IN-ADDR.ARPA':
+#       host => '70' ,
+#       zone => '128.168.192.IN-ADDR.ARPA' ,
+#       data => 'multihomed-server.example.com' ,
+#     }
+
+define dns_reverse_ptr_record (
+  $host,
+  $zone,
+  $ip = $name ) {
+
+  $reverse_zone = inline_template('<%= @ip.split(".")[0..-2].reverse.join(".") %>.IN-ADDR.ARPA')
+  $octet = inline_template('<%= @ip.split(".")[-1] %>')
+
+  dns::record::ptr { "${octet}.${reverse_zone}":
+    host => $octet,
+    zone => $reverse_zone,
+    data => "${host}.${zone}"
+  }
+}

--- a/manifests/record/a.pp
+++ b/manifests/record/a.pp
@@ -8,6 +8,7 @@ define dns::record::a (
   $data,
   $ttl = '',
   $ptr = false,
+  $all_ptr = false,
   $host = $name ) {
 
   $alias = "${name},A,${zone}"
@@ -19,15 +20,10 @@ define dns::record::a (
     data => $data
   }
 
-  if $ptr {
+  if $all_ptr {
+    dns_reverse_ptr_record { $data: host => $host, zone => $zone }
+  } elsif $ptr {
     $ip = inline_template('<%= @data.kind_of?(Array) ? @data.first : @data %>')
-    $reverse_zone = inline_template('<%= @ip.split(".")[0..-2].reverse.join(".") %>.IN-ADDR.ARPA')
-    $octet = inline_template('<%= @ip.split(".")[-1] %>')
-
-    dns::record::ptr { "${octet}.${reverse_zone}":
-      host => $octet,
-      zone => $reverse_zone,
-      data => "${host}.${zone}"
-    }
+    dns_reverse_ptr_record { $ip: host => $host, zone => $zone }
   }
 }

--- a/spec/defines/dns__record__a_spec.rb
+++ b/spec/defines/dns__record__a_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper'
+
+describe 'dns::record::a', :type => :define do
+  let(:title) { 'atest.example.com' }
+  let(:facts) { { :concat_basedir => '/tmp' } }
+
+  context 'passing a single ip address with ptr=>false' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => '192.168.128.42',
+        :ptr => false,
+        :all_ptr => false,
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.atest.example.com,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.42$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.42.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record') }
+  end
+
+  context 'passing a single ip address with ptr=>true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => '192.168.128.42',
+        :ptr => true,
+        :all_ptr => false,
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.atest.example.com,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.42$/) }
+    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.42.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^42\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing a single ip address with all_ptr=>true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => '192.168.128.42',
+        :ptr => false,
+        :all_ptr => true,
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.atest.example.com,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.42$/) }
+    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.42.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^42\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing a single ip address with ptr=>true and all_ptr=>true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => '192.168.128.42',
+        :ptr => true,
+        :all_ptr => true,
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.atest.example.com,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.42$/) }
+    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.42.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^42\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing multiple ip addresses with ptr=>false' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => false,
+        :all_ptr => false,
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.atest.example.com,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.68\natest\s+IN\s+A\s+192\.168\.128\.69\natest\s+IN\s+A\s+192\.168\.128\.70$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.68.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record') }
+  end
+
+  context 'passing multiple ip addresses with ptr=>true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => true,
+        :all_ptr => false,
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.atest.example.com,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.68\natest\s+IN\s+A\s+192\.168\.128\.69\natest\s+IN\s+A\s+192\.168\.128\.70$/) }
+    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.68.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing multiple ip addresses with all_ptr=>true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => false,
+        :all_ptr => true,
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.atest.example.com,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.68\natest\s+IN\s+A\s+192\.168\.128\.69\natest\s+IN\s+A\s+192\.168\.128\.70$/) }
+    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.68.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.69.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.70.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing multiple ip addresses with ptr=>true and all_ptr=>true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => true,
+        :all_ptr => true,
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.atest.example.com,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.68\natest\s+IN\s+A\s+192\.168\.128\.69\natest\s+IN\s+A\s+192\.168\.128\.70$/) }
+    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.68.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.69.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.70.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+end
+


### PR DESCRIPTION
This adds the `all_ptr=>`_[true|false]_ parameter to the `dns::record::a` type and sets up a private defined type that allows the `dns::record::a` type to create multiple `dns::record::ptr` resources for a records with multiple `data` values.

This also creates a set of rspec tests for the `dns::record::a` defined type.