### PR TITLE
Add support for delegation-only zone types.

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -127,9 +127,9 @@
 #
 # [*zone_type*]
 #   The type of DNS zone being described.  Can be one of `master`, `slave`
-#   (requires *slave_masters* to be set), or `forward` (requires both
-#   *allow_forwarder* and *forward_policy* to be set).  Defaults to
-#   `master`.
+#   (requires *slave_masters* to be set), `delegation-only`, or `forward`
+#   (requires both *allow_forwarder* and *forward_policy* to be set).
+#   Defaults to `master`.
 #
 define dns::zone (
   $soa = $::fqdn,
@@ -168,6 +168,13 @@ define dns::zone (
   $zone = $reverse ? {
     true    => "${name}.in-addr.arpa",
     default => $name
+  }
+
+  validate_string($zone_type)
+  $valid_zone_type_array = ['master', 'slave', 'forward', 'delegation-only']
+  if !member($valid_zone_type_array, $zone_type) {
+    $valid_zone_type_array_str = join($valid_zone_type_array, ',')
+    fail("The zone_type must be one of [${valid_zone_type_array}]")
   }
 
   $zone_file = "${dns::server::params::data_dir}/db.${name}"

--- a/spec/defines/dns__zone_spec.rb
+++ b/spec/defines/dns__zone_spec.rb
@@ -76,6 +76,18 @@ describe 'dns::zone' do
       end
   end
 
+  context 'with a delegation-only zone' do
+      let :params do
+          { :zone_type => 'delegation-only'
+          }
+      end
+      it 'should only have a type delegation-only entry' do
+          should contain_concat__fragment('named.conf.local.test.com.include').
+                     with_content(/zone \"test.com\" \{\s*type delegation-only;\s*\}/)
+      end 
+  end
+
+
   context 'with a forward zone' do
       let :params do
           { :allow_transfer => ['123.123.123.123'],

--- a/templates/zone.erb
+++ b/templates/zone.erb
@@ -10,7 +10,7 @@ type <%= @zone_type %>;
     <%- end -%>
     };
 <% end -%>
-<% if @zone_type != 'forward' -%>
+<% if (@zone_type != 'forward') && (@zone_type != 'delegation-only')-%>
     file "<%= @zone_file %>";
 <% end -%>
 <% if @zone_type == 'slave' -%>


### PR DESCRIPTION
Adds support for delegation-only zone types as specified on Pg. 105 of [Bind 9.10 Manual](https://www.isc.org/wp-content/uploads/2014/01/Bv910ARM.pdf). 

Added rspec test to ensure that a `dns::zone` with type `delegation-only` contains no other statements.