### PR TITLE
Control whether DNS-SEC support is enabled/disabled

### DIFF
--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -76,7 +76,9 @@
 #
 # [*dnssec_enable*]
 #   Controls whether to enable/disable DNS-SEC support. Boolean.
-#   Default: true, meaning DNS-SEC support is enabled
+#   Default is false on RedHat 5 (for the same reasons as 
+#   dnssec_validation above), and true on Debian and on RedHat 6
+#   and above.
 #
 # === Examples
 #
@@ -101,7 +103,7 @@ define dns::server::options (
   $zone_notify = undef,
   $also_notify = [],
   $dnssec_validation = $dns::server::params::default_dnssec_validation,
-  $dnssec_enable = true,
+  $dnssec_enable = $dns::server::params::default_dnsssec_enable,
 ) {
   $valid_check_names = ['fail', 'warn', 'ignore']
   $cfg_dir = $::dns::server::params::cfg_dir

--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -103,7 +103,7 @@ define dns::server::options (
   $zone_notify = undef,
   $also_notify = [],
   $dnssec_validation = $dns::server::params::default_dnssec_validation,
-  $dnssec_enable = $dns::server::params::default_dnsssec_enable,
+  $dnssec_enable = $dns::server::params::default_dnssec_enable,
 ) {
   $valid_check_names = ['fail', 'warn', 'ignore']
   $cfg_dir = $::dns::server::params::cfg_dir

--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -71,6 +71,12 @@
 #   included).  Default is "absent" on RedHat 5 (whose default bind
 #   package is too old to include dnssec validation), and "auto" on
 #   Debian and on RedHat 6 and above.
+#   Note: If *dnssec_enable* is set to false, this option is ignored.
+# 
+#
+# [*dnssec_enable*]
+#   Controls whether to enable/disable DNS-SEC support. Boolean.
+#   Default: true, meaning DNS-SEC support is enabled
 #
 # === Examples
 #
@@ -95,6 +101,7 @@ define dns::server::options (
   $zone_notify = undef,
   $also_notify = [],
   $dnssec_validation = $dns::server::params::default_dnssec_validation,
+  $dnssec_enable = true,
 ) {
   $valid_check_names = ['fail', 'warn', 'ignore']
   $cfg_dir = $::dns::server::params::cfg_dir
@@ -137,6 +144,11 @@ define dns::server::options (
   $valid_dnssec_validation = ['yes', 'no', 'auto', 'absent']
   if $dnssec_validation != undef and !member($valid_dnssec_validation, $dnssec_validation) {
     fail("The dnssec_validation must be ${valid_dnssec_validation}")
+  }
+
+  validate_bool($dnssec_enable)
+  if (! $dnssec_enable) and ($dnssec_validation != undef) {
+    warning('dnssec_enable is false. dnssec_validation will be ignored.')
   }
 
   file { $title:

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -15,6 +15,7 @@ class dns::server::params {
       $service            = 'bind9'
       $default_file       = '/etc/default/bind9'
       $default_template   = 'default.debian.erb'
+      $default_dnssec_enable     = true
       $default_dnssec_validation = 'auto'
       case $::operatingsystemmajrelease {
         '8': {
@@ -40,8 +41,10 @@ class dns::server::params {
       $default_file       = '/etc/sysconfig/named'
       $default_template   = 'default.redhat.erb'
       if $::operatingsystemmajrelease =~ /^[1-5]$/ {
+        $default_dnssec_enable     = false
         $default_dnssec_validation = 'absent'
       } else {
+        $default_dnssec_enable     = true
         $default_dnssec_validation = 'auto'
       }
     }

--- a/spec/defines/dns__server__options_spec.rb
+++ b/spec/defines/dns__server__options_spec.rb
@@ -245,7 +245,7 @@ describe 'dns::server::options', :type => :define do
       { :osfamily => 'RedHat', :operatingsystemmajrelease => '5', :concat_basedir => '/tmp' }
     end
     it { should contain_file('/etc/bind/named.conf.options').without_content(/dnssec-validation/) }
-    it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-enable yes/) }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-enable no/) }
   end
 
   context 'default value of dnssec_validation on RedHat 6' do

--- a/spec/defines/dns__server__options_spec.rb
+++ b/spec/defines/dns__server__options_spec.rb
@@ -245,6 +245,7 @@ describe 'dns::server::options', :type => :define do
       { :osfamily => 'RedHat', :operatingsystemmajrelease => '5', :concat_basedir => '/tmp' }
     end
     it { should contain_file('/etc/bind/named.conf.options').without_content(/dnssec-validation/) }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-enable yes/) }
   end
 
   context 'default value of dnssec_validation on RedHat 6' do
@@ -252,6 +253,7 @@ describe 'dns::server::options', :type => :define do
       { :osfamily => 'RedHat', :operatingsystemmajrelease => '6', :concat_basedir => '/tmp' }
     end
     it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-validation auto/) }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-enable yes/) }
   end
 
   context 'default value of dnssec_validation on Debian' do
@@ -259,6 +261,15 @@ describe 'dns::server::options', :type => :define do
       { :osfamily => 'Debian', :concat_basedir => '/tmp' }
     end
     it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-validation auto/) }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-enable yes/) }
+  end
+
+  context 'passing `false` to dnssec_enable' do
+    let :params do
+      { :dnssec_enable => false}
+    end
+    it { should contain_file('/etc/bind/named.conf.options').without_content(/dnssec-validation/) }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-enable no/) }
   end
 
   context 'passing `absent` to dnssec_validation' do
@@ -266,6 +277,7 @@ describe 'dns::server::options', :type => :define do
       { :dnssec_validation => 'absent' }
     end
     it { should contain_file('/etc/bind/named.conf.options').without_content(/dnssec-validation/) }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-enable yes/) }
   end
 
   context 'passing `auto` to dnssec_validation' do
@@ -273,6 +285,7 @@ describe 'dns::server::options', :type => :define do
       { :dnssec_validation => 'auto' }
     end
     it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-validation auto/) }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-enable yes/) }
   end
 
   context 'passing `yes` to dnssec_validation' do
@@ -280,6 +293,7 @@ describe 'dns::server::options', :type => :define do
       { :dnssec_validation => 'yes' }
     end
     it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-validation yes/) }
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/dnssec-enable yes/) }
   end
 
   context 'passing `no` to dnssec_validation' do

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -99,9 +99,13 @@ also-notify {
 	// If BIND logs error messages about the root key being expired,
 	// you will need to update your keys.  See https://www.isc.org/bind-keys
 	//========================================================================
-<% if @dnssec_validation != 'absent' -%>
+<% if @dnssec_enable -%>
+    dnssec-enable yes;
+    <% if @dnssec_validation != 'absent' -%>
 	dnssec-validation <%= @dnssec_validation %>;
+    <% end -%>
+<% else -%>
+    dnssec-enable no;
 <% end -%>
-
 	auth-nxdomain no;    # conform to RFC1035
 };


### PR DESCRIPTION
Add boolean option to `dns::server::options` to control whether DNS-SEC support is enabled/disabled. Also including tests & docs for same.

This option is default to false on RedHat 5 due to lack of DNS-SEC support, and true on all other platforms.