### PR TITLE
added new 'dns::server::options' recursion option

### DIFF
--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -72,11 +72,11 @@
 #   package is too old to include dnssec validation), and "auto" on
 #   Debian and on RedHat 6 and above.
 #   Note: If *dnssec_enable* is set to false, this option is ignored.
-# 
+#
 #
 # [*dnssec_enable*]
 #   Controls whether to enable/disable DNS-SEC support. Boolean.
-#   Default is false on RedHat 5 (for the same reasons as 
+#   Default is false on RedHat 5 (for the same reasons as
 #   dnssec_validation above), and true on Debian and on RedHat 6
 #   and above.
 #
@@ -87,26 +87,28 @@
 #   }
 #
 include dns::server::params
+#
 define dns::server::options (
-  $forwarders = [],
-  $transfers = [],
-  $listen_on = [],
-  $listen_on_ipv6 = [],
-  $listen_on_port = undef,
-  $allow_recursion = [],
-  $check_names_master = undef,
-  $check_names_slave = undef,
-  $check_names_response = undef,
-  $allow_query = [],
-  $statistic_channel_ip = undef,
+  $forwarders             = [],
+  $transfers              = [],
+  $listen_on              = [],
+  $listen_on_ipv6         = [],
+  $listen_on_port         = undef,
+  $allow_recursion        = [],
+  $check_names_master     = undef,
+  $check_names_slave      = undef,
+  $check_names_response   = undef,
+  $allow_query            = [],
+  $statistic_channel_ip   = undef,
   $statistic_channel_port = undef,
-  $zone_notify = undef,
-  $also_notify = [],
-  $dnssec_validation = $dns::server::params::default_dnssec_validation,
-  $dnssec_enable = $dns::server::params::default_dnssec_enable,
+  $zone_notify            = undef,
+  $also_notify            = [],
+  $recursion              = $dns::server::params::recursion,
+  $dnssec_validation      = $dns::server::params::default_dnssec_validation,
+  $dnssec_enable          = $dns::server::params::default_dnssec_enable,
 ) {
   $valid_check_names = ['fail', 'warn', 'ignore']
-  $cfg_dir = $::dns::server::params::cfg_dir
+  $cfg_dir  = $::dns::server::params::cfg_dir
   $data_dir = $::dns::server::params::data_dir
 
   if ! defined(Class['::dns::server']) {
@@ -141,6 +143,11 @@ define dns::server::options (
   $valid_zone_notify = ['yes', 'no', 'explicit', 'master-only']
   if $zone_notify != undef and !member($valid_zone_notify, $zone_notify) {
     fail("The zone_notify must be ${valid_zone_notify}")
+  }
+
+  $valid_recursion = ['yes', 'no', true, false]
+  if $recursion != undef and !member($valid_recursion, $recursion) {
+    fail("The recursion must be ${valid_recursion}")
   }
 
   $valid_dnssec_validation = ['yes', 'no', 'auto', 'absent']

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -15,6 +15,7 @@ class dns::server::params {
       $service            = 'bind9'
       $default_file       = '/etc/default/bind9'
       $default_template   = 'default.debian.erb'
+      $recursion          = 'yes'
       $default_dnssec_enable     = true
       $default_dnssec_validation = 'auto'
       case $::operatingsystemmajrelease {
@@ -40,6 +41,7 @@ class dns::server::params {
       $necessary_packages = [ 'bind', ]
       $default_file       = '/etc/sysconfig/named'
       $default_template   = 'default.redhat.erb'
+      $default_dnssec_enable      = true
       if $::operatingsystemmajrelease =~ /^[1-5]$/ {
         $default_dnssec_enable     = false
         $default_dnssec_validation = 'absent'

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -1,19 +1,21 @@
 options {
-	directory "<%= @data_dir %>";
+  directory "<%= @data_dir %>";
 
-	// If there is a firewall between you and nameservers you want
-	// to talk to, you may need to fix the firewall to allow multiple
-	// ports to talk.  See http://www.kb.cert.org/vuls/id/800113
+  // If there is a firewall between you and nameservers you want
+  // to talk to, you may need to fix the firewall to allow multiple
+  // ports to talk.  See http://www.kb.cert.org/vuls/id/800113
 
-	// If your ISP provided one or more IP addresses for stable.
-	// nameservers, you probably want to use them as forwarders...
-	// Uncomment the following block, and insert the addresses replacing.
-	// the all-0's placeholder.
+  // If your ISP provided one or more IP addresses for stable.
+  // nameservers, you probably want to use them as forwarders...
+  // Uncomment the following block, and insert the addresses replacing.
+  // the all-0's placeholder.
+
+    recursion <%= @recursion %>;
 
 <% if @forwarders.size == 0 then -%>
-    // forwarders {
-	// 	0.0.0.0;
-	// };
+  // forwarders {
+  //   0.0.0.0;
+  // };
 <% else -%>
     forwarders {
     <% @forwarders.each do |forwarder| -%>
@@ -53,7 +55,7 @@ options {
 <% if @allow_recursion.size != 0 then -%>
     allow-recursion {
     <% @allow_recursion.each do |recursion| -%>
-	<%= recursion -%>;
+  <%= recursion -%>;
     <% end -%>
     };
 <% end -%>
@@ -61,7 +63,7 @@ options {
 <% if @allow_query.size != 0 then -%>
     allow-query {
     <% @allow_query.each do |query| -%>
-	<%= query -%>;
+  <%= query -%>;
     <% end -%>
     };
 <% end -%>
@@ -95,17 +97,17 @@ also-notify {
 };
 <% end -%>
 
-	//========================================================================
-	// If BIND logs error messages about the root key being expired,
-	// you will need to update your keys.  See https://www.isc.org/bind-keys
-	//========================================================================
+    //========================================================================
+    // If BIND logs error messages about the root key being expired,
+    // you will need to update your keys.  See https://www.isc.org/bind-keys
+    //========================================================================
 <% if @dnssec_enable -%>
     dnssec-enable yes;
     <% if @dnssec_validation != 'absent' -%>
-	dnssec-validation <%= @dnssec_validation %>;
+    dnssec-validation <%= @dnssec_validation %>;
     <% end -%>
 <% else -%>
     dnssec-enable no;
 <% end -%>
-	auth-nxdomain no;    # conform to RFC1035
+    auth-nxdomain no;    # conform to RFC1035
 };


### PR DESCRIPTION
I added the way to configure the parameter "recursion" in 

``` puppet
  dns::server::options { '/etc/bind/named.conf.options':
    recursion => 'yes',
  }
```
