### PR TITLE
Custom version-string for increased security

### DIFF
--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -104,6 +104,7 @@ define dns::server::options (
   $also_notify = [],
   $dnssec_validation = $dns::server::params::default_dnssec_validation,
   $dnssec_enable = $dns::server::params::default_dnssec_enable,
+  $version_string = undef,
 ) {
   $valid_check_names = ['fail', 'warn', 'ignore']
   $cfg_dir = $::dns::server::params::cfg_dir

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -108,4 +108,7 @@ also-notify {
     dnssec-enable no;
 <% end -%>
 	auth-nxdomain no;    # conform to RFC1035
+<% if @version_string.size != 0 then -%>
+	version "<%= @version_string %>";
+<% end -%>
 };


### PR DESCRIPTION
Here is a small patch for adding an option to hide the dns-server’s version-info.