### PR TITLE
Added Package require

### DIFF
--- a/manifests/server/default.pp
+++ b/manifests/server/default.pp
@@ -43,7 +43,7 @@ class dns::server::default (
     mode    => '0644',
     content => template("${module_name}/${default_template}"),
     notify  => Class['dns::server::service'],
-    require => Package[$necessary_packages]
+    require => Package[$::dns::server::params::necessary_packages]
   }
 
 }

--- a/manifests/server/default.pp
+++ b/manifests/server/default.pp
@@ -43,6 +43,7 @@ class dns::server::default (
     mode    => '0644',
     content => template("${module_name}/${default_template}"),
     notify  => Class['dns::server::service'],
+    require => Package[$necessary_packages]
   }
 
 }

--- a/spec/classes/server/default_spec.rb
+++ b/spec/classes/server/default_spec.rb
@@ -32,6 +32,15 @@ describe 'dns::server::default' do
         it { should contain_file('/etc/default/bind9').with_content(/OPTIONS="-u bind -6"/) }
       end
 
+      context "requires bind9 and dnssec-tools package" do
+        it do
+          should contain_file('/etc/default/bind9').with({
+            'require' => ['Package[bind9]', 'Package[dnssec-tools]'],
+          })
+        end
+      end
+
+
     end
 
     context "passing wrong values and paths" do
@@ -114,6 +123,14 @@ describe 'dns::server::default' do
       context 'passing `no` to disable_zone_checking' do
         let(:params) {{ :disable_zone_checking => 'no' }}
         it { should contain_file('/etc/sysconfig/named').with_content(/DISABLE_ZONE_CHECKING=no/) }
+      end
+
+      context "requires bind package" do
+        it do
+          should contain_file('/etc/sysconfig/named').with({
+            'require' => 'Package[bind]',
+          })
+        end
       end
 
     end


### PR DESCRIPTION
When trying to integrate this module with my puppet environment, it kept claiming that the named user wasn't present. This was because the package hadn't yet been installed.

Error: Could not set 'present' on ensure: Could not find user named at 46:/vagrant/puppet-control/modules/dns/manifests/server/default.pp
Error: Could not set 'present' on ensure: Could not find user named at 46:/vagrant/puppet-control/modules/dns/manifests/server/default.pp
Wrapped exception:
Could not find user named
Error: /Stage[main]/Dns::Server::Default/File[/etc/sysconfig/named]/ensure: change from absent to present failed: Could not set 'present' on ensure: Could not find user named at 46:/vagrant/puppet-control/modules/dns/manifests/server/default.pp

This change makes sure the the file doesn't get created before the package (and user) is there.