### PR TITLE
Comparison of: String >= Integer, is not possible

### DIFF
--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -17,12 +17,13 @@ define dns::record (
 
   $zone_file_stage = "${data_dir}/db.${zone}.stage"
 
-  if $ttl !~ /^[0-9SsMmHhDdWw]+$/ and $ttl != '' {
-    fail("Define[dns::record]: TTL ${ttl} must be an integer within 0-2147483647 or explicitly specified time units, e.g. 1h30m.")
-  }
-
-  if is_integer($ttl) and !($ttl >= 0 and $ttl <= 2147483647) {
-    fail("Define[dns::record]: TTL ${ttl} must be an integer within 0-2147483647 or explicitly specified time units, e.g. 1h30m.")
+  case $ttl {
+    /^[0-9SsMmHhDdWw]+$/: {
+      fail("Define[dns::record]: TTL ${ttl} must be an integer within 0-2147483647 or explicitly specified time units, e.g. 1h30m.")
+    }
+    is_integer($ttl), !($ttl >= 0 and $ttl <= 2147483647):{
+      fail("Define[dns::record]: TTL ${ttl} must be an integer within 0-2147483647 or explicitly specified time units, e.g. 1h30m.")
+    }
   }
 
   concat::fragment{"db.${zone}.${name}.record":

--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -17,13 +17,12 @@ define dns::record (
 
   $zone_file_stage = "${data_dir}/db.${zone}.stage"
 
-  case $ttl {
-    /^[0-9SsMmHhDdWw]+$/: {
-      fail("Define[dns::record]: TTL ${ttl} must be an integer within 0-2147483647 or explicitly specified time units, e.g. 1h30m.")
-    }
-    is_integer($ttl), !($ttl >= 0 and $ttl <= 2147483647):{
-      fail("Define[dns::record]: TTL ${ttl} must be an integer within 0-2147483647 or explicitly specified time units, e.g. 1h30m.")
-    }
+  if $ttl !~ /^[0-9SsMmHhDdWw]+$/ and $ttl != '' {
+    fail("Define[dns::record]: TTL ${ttl} must be an integer within 0-2147483647 or explicitly specified time units, e.g. 1h30m.")
+  }
+
+  if is_integer($ttl) and !(($ttl + 0) >= 0 and ($ttl+ 0) <= 2147483647) {
+    fail("Define[dns::record]: TTL ${ttl} must be an integer within 0-2147483647 or explicitly specified time units, e.g. 1h30m.")
   }
 
   concat::fragment{"db.${zone}.${name}.record":


### PR DESCRIPTION
Current version casues this error when using any of the wrapper classes for records:

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Comparison of: String >= Integer, is not possible. Caused by 'A String is not comparable to a non String'. at /etc/puppetlabs/code/environments/production/modules/dns/manifests/record.pp:24:34 at /etc/puppetlabs/code/environments/production/modules/dns/manifests/record/cname.pp:19 on node

This error is caused by future parser not liking the comparison of integer and string, stole a really simple fix from: https://github.com/jfryman/puppet-nginx/issues/684

Also of note I couldn't get the tests to run even on the master branch, gave me a "NameError: uninitialized constant Syck" error, if you know how to fix that I will run them.  Tested with a clean gemset on Ruby 2.2.4.