### PR TITLE
Removed 'ensure' setting from concat::fragment statements

### DIFF
--- a/manifests/acl.pp
+++ b/manifests/acl.pp
@@ -25,7 +25,6 @@ define dns::acl (
   validate_array($data)
 
   concat::fragment { "named.conf.local.acl.${name}.include":
-    ensure  => $ensure,
     target  => "${dns::server::params::cfg_dir}/named.conf.local",
     order   => 2,
     content => template("${module_name}/acl.erb"),

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -50,7 +50,6 @@ class dns::server::config (
   }
 
   concat::fragment{'named.conf.local.header':
-    ensure  => present,
     target  => "${cfg_dir}/named.conf.local",
     order   => 1,
     content => "// File managed by Puppet.\n"

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -231,7 +231,6 @@ define dns::zone (
 
   # Include Zone in named.conf.local
   concat::fragment{"named.conf.local.${name}.include":
-    ensure  => $ensure,
     target  => "${cfg_dir}/named.conf.local",
     order   => 3,
     content => template("${module_name}/zone.erb")

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ajjahn-dns",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "Adam Jahn",
   "summary": "Module for provisioning DNS (bind9)",
   "license": "Apache-2.0",


### PR DESCRIPTION
The ensure parameter is deprecated for concat::fragment since [v2.0.0 of puppetlabs-concat](https://github.com/puppetlabs/puppetlabs-concat#ensure-1)

On systems with puppetlabs-concat v2.0.0 the ensure parameter is ignored for concat::fragment and it works just fine, so I removed the ensure settings.