### PR TITLE
Add `reverse => reverse` option to dns::zone

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,13 +279,14 @@ PLATFORMS
 DEPENDENCIES
   beaker (> 2.0.0)
   beaker-rspec (>= 5.1.0)
+  json
   pry
   puppet (~> 3.7.0)
   puppet-blacksmith
   puppet-lint
   puppet-syntax
   puppetlabs_spec_helper
-  rake
+  rake (< 11.0.0)
   rspec (< 3.2.0)
   rspec-core (= 3.1.7)
   rspec-puppet (~> 2.1)

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -80,6 +80,9 @@
 #
 # [*reverse*]
 #   If `true`, the zone will have `.in-addr.arpa` appended to it.
+#   If set to the string `reverse`, the `.`-separated components of
+#   the zone will be reversed, and then have `.in-addr.arpa` appended
+#   to it.
 #   Defaults to `false`.
 #
 # [*slave_masters*]
@@ -172,8 +175,9 @@ define dns::zone (
   }
 
   $zone = $reverse ? {
-    true    => "${name}.in-addr.arpa",
-    default => $name
+    'reverse' => join(reverse(split("arpa.in-addr.${name}", '\.')), '.'),
+    true      => "${name}.in-addr.arpa",
+    default   => $name
   }
 
   validate_string($zone_type)

--- a/spec/defines/dns__zone_spec.rb
+++ b/spec/defines/dns__zone_spec.rb
@@ -293,5 +293,23 @@ describe 'dns::zone' do
     it { should contain_concat__fragment('named.conf.local.test.com.include').with_content(/8\.8\.8\.8;/) }
   end
 
+  context 'passing true to reverse' do
+    let(:title) { '10.23.45' }
+    let :params do
+      { :reverse => true }
+    end
+    it { should contain_concat__fragment('named.conf.local.10.23.45.include').with_content(/zone "10\.23\.45\.in-addr\.arpa"/) }
+    it { should contain_concat__fragment('db.10.23.45.soa').with_content(/\$ORIGIN\s+10\.23\.45\.in-addr\.arpa\./) }
+  end
+
+  context 'passing reverse to reverse' do
+    let(:title) { '10.23.45' }
+    let :params do
+      { :reverse => 'reverse' }
+    end
+    it { should contain_concat__fragment('named.conf.local.10.23.45.include').with_content(/zone "45\.23\.10\.in-addr\.arpa"/) }
+    it { should contain_concat__fragment('db.10.23.45.soa').with_content(/\$ORIGIN\s+45\.23\.10\.in-addr\.arpa\./) }
+  end
+
 end
 


### PR DESCRIPTION
This will reverse the components of the zone title in addition to
appending `.in-addr.arpa` to the end.

For example:

    dns::zone { '10.23.45':
      ...
      reverse => reverse
      ...
    }

would result in a zone definition of:

    zone "45.23.10.in-addr.arpa" {
      ...
      file "db.10.23.45"
      ...
    }