### PR TITLE
issue #170: Produce proper DNS quoted strings for TXT and SPF records

### DIFF
--- a/manifests/record/txt.pp
+++ b/manifests/record/txt.pp
@@ -2,6 +2,69 @@
 #
 # Wrapper for dns::record for TXT records
 #
+# === Parameters
+#
+# [*zone*]
+#   The zone in which this record should be created.
+# [*data*]
+#   The value of the TXT record.  (See the @Formatting section below)
+# [*ttl*]
+#   The time-to-live value for the record.  Defaults to an empty string,
+#   which means BIND will use the zone's TTL setting.
+# [*host*]
+#   The host name for this record.  Defaults to the resource title.
+#
+# === Formatting
+#
+# DNS `TXT` and `SPF` records have specific formatting applied to their
+# *data* values, based on the requirements in
+# [RFC1035](https://tools.ietf.org/html/rfc1035.html) sections
+# [3.3](https://tools.ietf.org/html/rfc1035.html#section-3.3),
+# [3.3.14](https://tools.ietf.org/html/rfc1035.html#section-3.3.14), and
+# [5](https://tools.ietf.org/html/rfc1035.html#section-5).
+#
+# When the `TXT` or `SPF` record is created in the zone file, the data
+# value will be split into multiple strings of no more than 255 characters
+# each; within each character string, double-quotes (`"`) and backslashes
+# (`\\`) will be escaped by adding a backslash before them (`\\#` / `\\\\`);
+# each individual string will be surrounded by double-quotes; and the strings
+# will be joined back together with spaces in between.
+#
+# === Examples
+#
+#     dns::record::txt { 'txt1':
+#         zone => 'example.com',
+#         data => 'this is a test record',
+#     }
+#
+# will generate:
+#
+#     txt1            IN      TXT     "this is a test record"
+#
+# ---
+#
+#     dns::record::txt { 'txt2':
+#         zone => 'example.com',
+#         data => 'this is "another" test record',
+#     }
+#
+# will generate:
+#
+#     txt2            IN      TXT     "this is \"another\" test record"
+#
+# ---
+#
+#     dns::record::txt { 'txt3.example.com':
+#         zone => 'example.com',
+#         data => 'this is a' + ' very'*60 + ' long test record',
+#         host => 'txt3',
+#     }
+#
+# will generate:
+#
+#     txt3            IN      TXT     "this is a very very very...very " "very very...very long test record"
+#
+
 define dns::record::txt (
   $zone,
   $data,

--- a/spec/defines/dns__record__txt_spec.rb
+++ b/spec/defines/dns__record__txt_spec.rb
@@ -14,7 +14,7 @@ describe 'dns::record::txt', :type => :define do
     it { should contain_concat__fragment('db.example.com.txttest,TXT,example.com.record').with_content(/^txttest\s+IN\s+TXT\s+"testing"$/) }
   end
 
-  context 'passing a string that includes a quote should result in the quote being escaped' do
+  context 'passing a string that includes a quote character should result in the dns module escaping the quote' do
     let :params do {
         :host => 'txttest',
         :zone => 'example.com',
@@ -24,7 +24,7 @@ describe 'dns::record::txt', :type => :define do
     it { should contain_concat__fragment('db.example.com.txttest,TXT,example.com.record').with_content(/^txttest\s+IN\s+TXT\s+"this is a \\"test\\""$/) }
   end
 
-  context 'passing a long string should result in multiple quoted strings' do
+  context 'passing a long string should result in the dns module splitting that string into multiple quoted strings' do
     let :params do {
         :host => 'txttest',
         :zone => 'example.com',

--- a/spec/defines/dns__record__txt_spec.rb
+++ b/spec/defines/dns__record__txt_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'dns::record::txt', :type => :define do
+  let(:title) { 'txttest' }
+  let(:facts) { { :concat_basedir => '/tmp' } }
+
+  context 'passing a simple string should result in a quoted string' do
+    let :params do {
+        :host => 'txttest',
+        :zone => 'example.com',
+        :data => 'testing',
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.txttest,TXT,example.com.record').with_content(/^txttest\s+IN\s+TXT\s+"testing"$/) }
+  end
+
+  context 'passing a string that includes a quote should result in the quote being escaped' do
+    let :params do {
+        :host => 'txttest',
+        :zone => 'example.com',
+        :data => 'this is a "test"',
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.txttest,TXT,example.com.record').with_content(/^txttest\s+IN\s+TXT\s+"this is a \\"test\\""$/) }
+  end
+
+  context 'passing a long string should result in multiple quoted strings' do
+    let :params do {
+        :host => 'txttest',
+        :zone => 'example.com',
+        :data => 'this is a ' + 'very '*60 + 'long test',
+    } end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.example.com.txttest,TXT,example.com.record').with_content(/^txttest\s+IN\s+TXT\s+"this is a very.*" ".*very long test"$/) }
+  end
+
+end
+

--- a/templates/zone_record.erb
+++ b/templates/zone_record.erb
@@ -3,10 +3,42 @@ data_a = @data.is_a?(String) ? @data.lines.to_a : @data
 
 data_a.each do |data_item|
 if %w[TXT SPF].include?(@record.upcase)
-  # for TXT and SPF records, transform the data item into a valid text record value:
-  # use String.unpack to split the text value into 255 character chunks;
-  # then use Array.collect to turn each chunk into a valid quoted character string;
-  # finally join the quoted character strings together, separated by a space.
+  # DNS TXT and SPF records have specific formatting requirements.
+  #
+  # 1. per RFC1035 section 3.3.14, they are composed of one or more
+  # character strings.
+  #
+  # 2. per RFC1035 section 3.3, each character string can be up to 255
+  # characters (section 3.3 indicates 256 octets, but includes the length
+  # octet as part of that count).
+  #
+  # 3. per common usage, if a TXT record consists of multiple character
+  # strings, the application processing that record concatenates the
+  # character strings together with no intervening characters.
+  #
+  # 4. per RFC1035 section 5, if a character string includes spaces,
+  # it must be enclosed in double-quotes ("). Within the double-quotes,
+  # any character can occur except another double-quote; double-quotes
+  # must be escaped by backslashes (\) (and by implication, backslashes
+  # must also be escaped by backslashes).
+  #
+  # Based on these requirements, TXT and SPF records data items need
+  # to be processed in this manner:
+  #
+  # 1.  split the data_item into 255 (at most) character chunks.
+  #         (via `unpack` with a format string consisting of one 'a255'
+  #         for every 255 characters in the data item, rounded up)
+  #
+  # 2.  escape all double-quotes and backslashes within each chunk by
+  #     inserting a backslash before the escaped character.
+  #         (via a `gsub` within a `collect` over the array of chunks)
+  #
+  # 3.  surround each chunk with double-quotes.
+  #         (within the same `collect` over the array of chunks`
+  #
+  # 4.  join the chunks back together with a space between each chunk.
+  #         (via `join(' ')`)
+  #
   data_item = data_item.unpack('a255' * ((data_item.length / 255.0).ceil())).collect { |x| '"' + x.gsub(/([\\"])/, '\\\\\\1') + '"' }.join(' ')
 end
 -%>

--- a/templates/zone_record.erb
+++ b/templates/zone_record.erb
@@ -1,8 +1,14 @@
 <%
-delimiter = %w[TXT SPF].include?(@record.upcase) ? '"' : ''
 data_a = @data.is_a?(String) ? @data.lines.to_a : @data
 
 data_a.each do |data_item|
+if %w[TXT SPF].include?(@record.upcase)
+  # for TXT and SPF records, transform the data item into a valid text record value:
+  # use String.unpack to split the text value into 255 character chunks;
+  # then use Array.collect to turn each chunk into a valid quoted character string;
+  # finally join the quoted character strings together, separated by a space.
+  data_item = data_item.unpack('a255' * ((data_item.length / 255.0).ceil())).collect { |x| '"' + x.gsub(/([\\"])/, '\\\\\\1') + '"' }.join(' ')
+end
 -%>
-<%= @host %>	<%= @ttl %>	<%= @dns_class %>	<%= @record.upcase %><%= @record.upcase == 'MX' ? " #{@preference}" : '' %>	<%= delimiter %><%= data_item %><%= delimiter %>
+<%= @host %>	<%= @ttl %>	<%= @dns_class %>	<%= @record.upcase %><%= @record.upcase == 'MX' ? " #{@preference}" : '' %>	<%= data_item %>
 <% end -%>

--- a/templates/zone_record.erb
+++ b/templates/zone_record.erb
@@ -34,7 +34,7 @@ if %w[TXT SPF].include?(@record.upcase)
   #         (via a `gsub` within a `collect` over the array of chunks)
   #
   # 3.  surround each chunk with double-quotes.
-  #         (within the same `collect` over the array of chunks`
+  #         (within the same `collect` over the array of chunks)
   #
   # 4.  join the chunks back together with a space between each chunk.
   #         (via `join(' ')`)


### PR DESCRIPTION
#170 This change modifies the `zone_record.erb` template so that it
processes the data values for TXT and SPF records to produce proper
DNS quoted strings (of no more than 255 characters, with embedded
quotes and backslashes escaped with backslashes).

It also adds SPEC tests for the TXT record type.