### PR TITLE
Fix typos in `dns::collector` and `dns::zone`

### DIFF
--- a/manifests/collector.pp
+++ b/manifests/collector.pp
@@ -2,7 +2,7 @@
 #
 # ?
 class dns::collector {
-  Member <<| |>> {
+  Dns::Member <<| |>> {
     require => Class['dns::server'],
     notify  => Class['dns::server::service']
   }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -164,7 +164,7 @@ define dns::zone (
   validate_array($allow_transfer)
   validate_array($allow_forwarder)
   if !member(['first', 'only'], $forward_policy) {
-    error('The forward policy can only be set to either first or only')
+    fail('The forward policy can only be set to either first or only')
   }
   validate_array($allow_query)
 


### PR DESCRIPTION
`dns::collector` should be collecting resources of type `Dns::Member`, not bare `Member`.

`dns::zone` had a call to `error()` which should have been `fail()`