### PR TITLE
Automated Travis Releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ rvm:
   - 2.1
 
 env:
-  - PUPPET_VERSION="~> 2.7.0"
+  - PUPPET_VERSION="~> 2.7.0" DEPLOY_TO_FORGE=yes
   - PUPPET_VERSION="~> 3.1.0"
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
@@ -25,13 +25,13 @@ script: bundle exec rake test
 matrix:
   exclude:
   - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
+    env: PUPPET_VERSION="~> 2.7.0" DEPLOY_TO_FORGE=yes
   - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
+    env: PUPPET_VERSION="~> 2.7.0" DEPLOY_TO_FORGE=yes
   - rvm: 2.0.0
     env: PUPPET_VERSION="~> 3.1.0"
   - rvm: 2.1
-    env: PUPPET_VERSION="~> 2.7.0"
+    env: PUPPET_VERSION="~> 2.7.0" DEPLOY_TO_FORGE=yes
   - rvm: 2.1
     env: PUPPET_VERSION="~> 3.1.0"
   - rvm: 2.1
@@ -40,3 +40,16 @@ matrix:
     env: PUPPET_VERSION="~> 3.3.0"
   - rvm: 2.1
     env: PUPPET_VERSION="~> 3.4.0"
+
+deploy:
+  provider: puppetforge
+  # Till https://github.com/travis-ci/dpl/issues/487 is closed
+  deploy:
+    branch: ha-bug-puppet-forge
+  user: ajjahn
+  password:
+    secure: "Add this password by running 'travis encrypt'"
+  on:
+    tags: true
+    condition: "$DEPLOY_TO_FORGE = yes"
+ 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,197 @@
+# Change Log
+
+## [2.1.0](https://github.com/ajjahn/puppet-dns/tree/2.1.0) (2016-09-07)
+[Full Changelog](https://github.com/ajjahn/puppet-dns/compare/v2.0.2...2.1.0)
+
+**Closed issues:**
+
+- TXT record types should properly format the data value [\#170](https://github.com/ajjahn/puppet-dns/issues/170)
+- Tags and Forge releases for 2.0.1 and 2.0.2 [\#167](https://github.com/ajjahn/puppet-dns/issues/167)
+- How to handle class B nets [\#166](https://github.com/ajjahn/puppet-dns/issues/166)
+- cut releases more frequently. :\) [\#157](https://github.com/ajjahn/puppet-dns/issues/157)
+- doesnt work with dynamic dns [\#54](https://github.com/ajjahn/puppet-dns/issues/54)
+
+**Merged pull requests:**
+
+- Ignore /\*.lock files [\#175](https://github.com/ajjahn/puppet-dns/pull/175) ([sspreitzer](https://github.com/sspreitzer))
+- Make lint happy:  change variables class\_\[ABC\]\_\* to class\_\[abc\]\_\* [\#174](https://github.com/ajjahn/puppet-dns/pull/174) ([jearls](https://github.com/jearls))
+- Fix typos in `dns::collector` and `dns::zone` [\#173](https://github.com/ajjahn/puppet-dns/pull/173) ([jearls](https://github.com/jearls))
+- Allow dynamic dns, fixes ajjahn/puppet-dns\#54 [\#172](https://github.com/ajjahn/puppet-dns/pull/172) ([sspreitzer](https://github.com/sspreitzer))
+- issue \#170: Produce proper DNS quoted strings for TXT and SPF records [\#171](https://github.com/ajjahn/puppet-dns/pull/171) ([jearls](https://github.com/jearls))
+- Correct indentation of template. [\#169](https://github.com/ajjahn/puppet-dns/pull/169) ([MemberIT](https://github.com/MemberIT))
+- Bugfix/template named options [\#168](https://github.com/ajjahn/puppet-dns/pull/168) ([MemberIT](https://github.com/MemberIT))
+
+## [v2.0.2](https://github.com/ajjahn/puppet-dns/tree/v2.0.2) (2016-05-24)
+[Full Changelog](https://github.com/ajjahn/puppet-dns/compare/v2.0.0...v2.0.2)
+
+**Closed issues:**
+
+- Is dependency on electrical-file\_concat still required? [\#160](https://github.com/ajjahn/puppet-dns/issues/160)
+- seemingly random order within the zonefile [\#154](https://github.com/ajjahn/puppet-dns/issues/154)
+- Concat dependency causing builds to fail [\#142](https://github.com/ajjahn/puppet-dns/issues/142)
+- Version update [\#141](https://github.com/ajjahn/puppet-dns/issues/141)
+
+**Merged pull requests:**
+
+- Remove unneeded dependency on electrical/file\_concat module [\#165](https://github.com/ajjahn/puppet-dns/pull/165) ([jearls](https://github.com/jearls))
+- Add `reverse =\> reverse` option to dns::zone [\#162](https://github.com/ajjahn/puppet-dns/pull/162) ([jearls](https://github.com/jearls))
+- Add `notify\_source` and `transfer\_source` to `dns::server::options` [\#161](https://github.com/ajjahn/puppet-dns/pull/161) ([jearls](https://github.com/jearls))
+- Adjust Gemfile to Fix Tests [\#159](https://github.com/ajjahn/puppet-dns/pull/159) ([solarkennedy](https://github.com/solarkennedy))
+- Removed 'ensure' setting from concat::fragment statements [\#158](https://github.com/ajjahn/puppet-dns/pull/158) ([Loewe88](https://github.com/Loewe88))
+- Comparison of: String \>= Integer, is not possible [\#155](https://github.com/ajjahn/puppet-dns/pull/155) ([wazoo](https://github.com/wazoo))
+- Added Package require [\#153](https://github.com/ajjahn/puppet-dns/pull/153) ([mooreandrew](https://github.com/mooreandrew))
+- Allow query zone [\#152](https://github.com/ajjahn/puppet-dns/pull/152) ([gcmalloc](https://github.com/gcmalloc))
+- Fix default spec, a class not a define [\#151](https://github.com/ajjahn/puppet-dns/pull/151) ([solarkennedy](https://github.com/solarkennedy))
+- Control whether DNS-SEC support is enabled/disabled [\#146](https://github.com/ajjahn/puppet-dns/pull/146) ([evidex](https://github.com/evidex))
+- \[WIP\] Fix fixtures [\#145](https://github.com/ajjahn/puppet-dns/pull/145) ([solarkennedy](https://github.com/solarkennedy))
+- Empty Zone Generation control [\#144](https://github.com/ajjahn/puppet-dns/pull/144) ([evidex](https://github.com/evidex))
+- Add support for delegation-only zone types. [\#143](https://github.com/ajjahn/puppet-dns/pull/143) ([evidex](https://github.com/evidex))
+- Add `all` and `first` values to `ptr` parameter of `dns::record::a` [\#138](https://github.com/ajjahn/puppet-dns/pull/138) ([jearls](https://github.com/jearls))
+
+## [v2.0.0](https://github.com/ajjahn/puppet-dns/tree/v2.0.0) (2015-12-03)
+[Full Changelog](https://github.com/ajjahn/puppet-dns/compare/v1.2.0...v2.0.0)
+
+**Closed issues:**
+
+- Outdated dependencies make this module incompatible with other modules. [\#120](https://github.com/ajjahn/puppet-dns/issues/120)
+- Fatal Regression in \#112- bad config means bind will not start. [\#115](https://github.com/ajjahn/puppet-dns/issues/115)
+- Adding record to multiple zones or all zones? [\#105](https://github.com/ajjahn/puppet-dns/issues/105)
+- Large Number of Records? [\#104](https://github.com/ajjahn/puppet-dns/issues/104)
+- Tag New Release [\#97](https://github.com/ajjahn/puppet-dns/issues/97)
+- SOA has additional "." [\#93](https://github.com/ajjahn/puppet-dns/issues/93)
+- Error finding a dependency. [\#78](https://github.com/ajjahn/puppet-dns/issues/78)
+- Allow "type forward" without file-statement [\#64](https://github.com/ajjahn/puppet-dns/issues/64)
+- 'dnssec-validation auto' not supported in Debian Squeeze \(Bind 9.7.3\) [\#52](https://github.com/ajjahn/puppet-dns/issues/52)
+
+**Merged pull requests:**
+
+- Test NS records, provide example for README [\#140](https://github.com/ajjahn/puppet-dns/pull/140) ([roderickm](https://github.com/roderickm))
+- Properly escape the { and } in the listen-on-v6 regexp check. [\#139](https://github.com/ajjahn/puppet-dns/pull/139) ([jearls](https://github.com/jearls))
+- fix variable access preference with @preference [\#136](https://github.com/ajjahn/puppet-dns/pull/136) ([timogoebel](https://github.com/timogoebel))
+- fixes for puppet future parser support [\#135](https://github.com/ajjahn/puppet-dns/pull/135) ([timogoebel](https://github.com/timogoebel))
+- Make "listen-on-v6" a configurable option [\#134](https://github.com/ajjahn/puppet-dns/pull/134) ([djm256](https://github.com/djm256))
+- Allow the dns::zone::slave\_masters parameter to be an array [\#133](https://github.com/ajjahn/puppet-dns/pull/133) ([jearls](https://github.com/jearls))
+- params.pp: excluded dnssec-tools from $necessary\_package for debian 8 [\#131](https://github.com/ajjahn/puppet-dns/pull/131) ([Gril258](https://github.com/Gril258))
+- Added support to modify service startup [\#130](https://github.com/ajjahn/puppet-dns/pull/130) ([Cicco0](https://github.com/Cicco0))
+- add updated Gemfile.lock [\#128](https://github.com/ajjahn/puppet-dns/pull/128) ([jearls](https://github.com/jearls))
+- Added initial acceptance test framework [\#126](https://github.com/ajjahn/puppet-dns/pull/126) ([solarkennedy](https://github.com/solarkennedy))
+- Fix the `directory` option in named.conf.options [\#125](https://github.com/ajjahn/puppet-dns/pull/125) ([darkfoxprime](https://github.com/darkfoxprime))
+- Make dnssec validation a configurable option. [\#124](https://github.com/ajjahn/puppet-dns/pull/124) ([darkfoxprime](https://github.com/darkfoxprime))
+- fix zone template's @allow\_transfer check [\#123](https://github.com/ajjahn/puppet-dns/pull/123) ([darkfoxprime](https://github.com/darkfoxprime))
+- Correct path for named.conf.options in tests/init.pp [\#122](https://github.com/ajjahn/puppet-dns/pull/122) ([darkfoxprime](https://github.com/darkfoxprime))
+- Remove invalid reference to dns::server::options::forwarder [\#121](https://github.com/ajjahn/puppet-dns/pull/121) ([darkfoxprime](https://github.com/darkfoxprime))
+- Named.options fix [\#119](https://github.com/ajjahn/puppet-dns/pull/119) ([tedivm](https://github.com/tedivm))
+- Fixes \#93 - Avoid the extra dot in the soa [\#117](https://github.com/ajjahn/puppet-dns/pull/117) ([oloc](https://github.com/oloc))
+- Updated concat module version [\#116](https://github.com/ajjahn/puppet-dns/pull/116) ([tedivm](https://github.com/tedivm))
+- Fix comment syntax in named.conf template [\#114](https://github.com/ajjahn/puppet-dns/pull/114) ([jaxim](https://github.com/jaxim))
+- Add param to manage packages [\#113](https://github.com/ajjahn/puppet-dns/pull/113) ([jaxim](https://github.com/jaxim))
+- issue 101: take control of named.conf. [\#112](https://github.com/ajjahn/puppet-dns/pull/112) ([jearls](https://github.com/jearls))
+- Add notify to server options & also\_notify to server and zone options. [\#110](https://github.com/ajjahn/puppet-dns/pull/110) ([jearls](https://github.com/jearls))
+- Remove dnssec-tools from RedHat package list. [\#108](https://github.com/ajjahn/puppet-dns/pull/108) ([jearls](https://github.com/jearls))
+- Added file\_concat as a dependent module [\#103](https://github.com/ajjahn/puppet-dns/pull/103) ([solarkennedy](https://github.com/solarkennedy))
+- Use resource names instead of hosts for the aliases of dns record types.  With spec test file. [\#100](https://github.com/ajjahn/puppet-dns/pull/100) ([jearls](https://github.com/jearls))
+- zone files should only be created or modified for master zones [\#99](https://github.com/ajjahn/puppet-dns/pull/99) ([jearls](https://github.com/jearls))
+- spec tests: fix invalid range in regexp [\#98](https://github.com/ajjahn/puppet-dns/pull/98) ([jearls](https://github.com/jearls))
+- Fixed a bug where key did not work on redhat due to incorrect pkg name [\#87](https://github.com/ajjahn/puppet-dns/pull/87) ([fhaynes](https://github.com/fhaynes))
+- Bind stats [\#77](https://github.com/ajjahn/puppet-dns/pull/77) ([gcmalloc](https://github.com/gcmalloc))
+
+## [v1.2.0](https://github.com/ajjahn/puppet-dns/tree/v1.2.0) (2015-04-10)
+[Full Changelog](https://github.com/ajjahn/puppet-dns/compare/v1.1.0...v1.2.0)
+
+**Closed issues:**
+
+- Custom NS not supported- can't properly handle domain forwarding [\#95](https://github.com/ajjahn/puppet-dns/issues/95)
+- Error: Could not set 'present' on ensure: No such file or directory - /etc/bind/named.conf.options20150404-12319-h6cff6.lock [\#94](https://github.com/ajjahn/puppet-dns/issues/94)
+- dnssec-tools not available in centos 7 epel [\#83](https://github.com/ajjahn/puppet-dns/issues/83)
+- Invalid relationship errors with concat [\#81](https://github.com/ajjahn/puppet-dns/issues/81)
+- Dependency required for repository "epel" on CentOS [\#79](https://github.com/ajjahn/puppet-dns/issues/79)
+- New Release 1.1.0 [\#75](https://github.com/ajjahn/puppet-dns/issues/75)
+
+**Merged pull requests:**
+
+- Added NS record type [\#96](https://github.com/ajjahn/puppet-dns/pull/96) ([tedivm](https://github.com/tedivm))
+- Added in feature allowing for global allow-transfer [\#90](https://github.com/ajjahn/puppet-dns/pull/90) ([fhaynes](https://github.com/fhaynes))
+- Fixed a bug where the secret line was not ending a ; [\#89](https://github.com/ajjahn/puppet-dns/pull/89) ([fhaynes](https://github.com/fhaynes))
+- Fixed a bug where the key was being written with }: and not }; [\#88](https://github.com/ajjahn/puppet-dns/pull/88) ([fhaynes](https://github.com/fhaynes))
+- fixed params.pp for rhel 7 and added fixes for concat issues [\#84](https://github.com/ajjahn/puppet-dns/pull/84) ([ITBlogger](https://github.com/ITBlogger))
+- Added a description to make RHEL/CentOS users aware that EPEL is required. [\#82](https://github.com/ajjahn/puppet-dns/pull/82) ([robertdebock](https://github.com/robertdebock))
+- Test check\_names\_response with wrong string [\#76](https://github.com/ajjahn/puppet-dns/pull/76) ([roderickm](https://github.com/roderickm))
+
+## [v1.1.0](https://github.com/ajjahn/puppet-dns/tree/v1.1.0) (2015-02-03)
+[Full Changelog](https://github.com/ajjahn/puppet-dns/compare/v1.0.0...v1.1.0)
+
+**Closed issues:**
+
+- Version 2.0.0 [\#38](https://github.com/ajjahn/puppet-dns/issues/38)
+
+**Merged pull requests:**
+
+- EL Compatible [\#74](https://github.com/ajjahn/puppet-dns/pull/74) ([roderickm](https://github.com/roderickm))
+- cleanup of inline rdocs in `dns::server::options` class [\#73](https://github.com/ajjahn/puppet-dns/pull/73) ([talisto](https://github.com/talisto))
+- allow port to be customized in dns::server::options [\#72](https://github.com/ajjahn/puppet-dns/pull/72) ([talisto](https://github.com/talisto))
+- MX preference fix, unique alias, add tests [\#71](https://github.com/ajjahn/puppet-dns/pull/71) ([roderickm](https://github.com/roderickm))
+- Add listen-on option \(with tests\) [\#70](https://github.com/ajjahn/puppet-dns/pull/70) ([roderickm](https://github.com/roderickm))
+- Use the new build env on Travis [\#68](https://github.com/ajjahn/puppet-dns/pull/68) ([joshk](https://github.com/joshk))
+- Zone with "type forward" are now without "file"-line [\#66](https://github.com/ajjahn/puppet-dns/pull/66) ([fr3dm4n](https://github.com/fr3dm4n))
+- fix README example [\#65](https://github.com/ajjahn/puppet-dns/pull/65) ([rkcpi](https://github.com/rkcpi))
+- Update README.md [\#62](https://github.com/ajjahn/puppet-dns/pull/62) ([kylecannon](https://github.com/kylecannon))
+
+## [v1.0.0](https://github.com/ajjahn/puppet-dns/tree/v1.0.0) (2014-10-19)
+[Full Changelog](https://github.com/ajjahn/puppet-dns/compare/v0.1.4...v1.0.0)
+
+**Closed issues:**
+
+- Error 400 on SERVER: Duplicate declaration: Dns::Record::A\[server1\] is already declared [\#44](https://github.com/ajjahn/puppet-dns/issues/44)
+- Change zone-serial only on record updates \(this a solution\) [\#24](https://github.com/ajjahn/puppet-dns/issues/24)
+- Possibility to set forwarders [\#22](https://github.com/ajjahn/puppet-dns/issues/22)
+- Provide a feature to set the /etc/bind/named.conf.options file [\#21](https://github.com/ajjahn/puppet-dns/issues/21)
+- module not found when installing from the forge using puppet module install [\#15](https://github.com/ajjahn/puppet-dns/issues/15)
+
+**Merged pull requests:**
+
+- Updated docs [\#60](https://github.com/ajjahn/puppet-dns/pull/60) ([solarkennedy](https://github.com/solarkennedy))
+- Create ns.pp [\#53](https://github.com/ajjahn/puppet-dns/pull/53) ([gilneidp](https://github.com/gilneidp))
+- Fix 'Usage' section in dns::server::options [\#51](https://github.com/ajjahn/puppet-dns/pull/51) ([strangeman](https://github.com/strangeman))
+- Fix 'Usage' section in dns::acl [\#50](https://github.com/ajjahn/puppet-dns/pull/50) ([strangeman](https://github.com/strangeman))
+- Spec refactor [\#49](https://github.com/ajjahn/puppet-dns/pull/49) ([danzilio](https://github.com/danzilio))
+- Reformatted dns::key and wrote tests for it [\#48](https://github.com/ajjahn/puppet-dns/pull/48) ([danzilio](https://github.com/danzilio))
+- allow recursion [\#47](https://github.com/ajjahn/puppet-dns/pull/47) ([gcmalloc](https://github.com/gcmalloc))
+- Adding a forward option for a zone. [\#46](https://github.com/ajjahn/puppet-dns/pull/46) ([gcmalloc](https://github.com/gcmalloc))
+- Update zone-serial only on changing zone-records \(sed version\) [\#45](https://github.com/ajjahn/puppet-dns/pull/45) ([kubashin-a](https://github.com/kubashin-a))
+- Use FQDN as PTR name instead of octet [\#43](https://github.com/ajjahn/puppet-dns/pull/43) ([kubashin-a](https://github.com/kubashin-a))
+- El compatible [\#41](https://github.com/ajjahn/puppet-dns/pull/41) ([Sereinity](https://github.com/Sereinity))
+- Solved Syntax error at 'inherits' in ::dns::server::options.pp:18 [\#40](https://github.com/ajjahn/puppet-dns/pull/40) ([n1tr0g](https://github.com/n1tr0g))
+- Params refactor for future OS support with tests... on top of danzilio's refactor [\#34](https://github.com/ajjahn/puppet-dns/pull/34) ([solarkennedy](https://github.com/solarkennedy))
+- Allow transfer... on top of danzilios refactor [\#33](https://github.com/ajjahn/puppet-dns/pull/33) ([solarkennedy](https://github.com/solarkennedy))
+- Update zone\_file.erb [\#31](https://github.com/ajjahn/puppet-dns/pull/31) ([seanscottking](https://github.com/seanscottking))
+- Update Modulefile [\#30](https://github.com/ajjahn/puppet-dns/pull/30) ([seanscottking](https://github.com/seanscottking))
+- ACL [\#29](https://github.com/ajjahn/puppet-dns/pull/29) ([danzilio](https://github.com/danzilio))
+- Refactored the module with a better Gemfile and Rakefile. [\#28](https://github.com/ajjahn/puppet-dns/pull/28) ([danzilio](https://github.com/danzilio))
+- Template changes [\#27](https://github.com/ajjahn/puppet-dns/pull/27) ([ppouliot](https://github.com/ppouliot))
+- Add possibility to set forwarders [\#23](https://github.com/ajjahn/puppet-dns/pull/23) ([zeleznypa](https://github.com/zeleznypa))
+- Added support for SRV DNS record types. [\#20](https://github.com/ajjahn/puppet-dns/pull/20) ([samcday](https://github.com/samcday))
+
+## [v0.1.4](https://github.com/ajjahn/puppet-dns/tree/v0.1.4) (2013-02-12)
+[Full Changelog](https://github.com/ajjahn/puppet-dns/compare/v0.1.3...v0.1.4)
+
+## [v0.1.3](https://github.com/ajjahn/puppet-dns/tree/v0.1.3) (2013-01-14)
+**Closed issues:**
+
+- Named.conf Updates [\#13](https://github.com/ajjahn/puppet-dns/issues/13)
+- Building PTR Records Fails With Same Resource Defined In Seperate Zones [\#12](https://github.com/ajjahn/puppet-dns/issues/12)
+- Zone regenerates w/ every Puppet run [\#3](https://github.com/ajjahn/puppet-dns/issues/3)
+
+**Merged pull requests:**
+
+- add supoprt for managing slave zones [\#14](https://github.com/ajjahn/puppet-dns/pull/14) ([aussielunix](https://github.com/aussielunix))
+- MX Records need a host field [\#11](https://github.com/ajjahn/puppet-dns/pull/11) ([aaronbbrown](https://github.com/aaronbbrown))
+- Syntax error when using strings [\#10](https://github.com/ajjahn/puppet-dns/pull/10) ([aaronbbrown](https://github.com/aaronbbrown))
+- Dependency version [\#9](https://github.com/ajjahn/puppet-dns/pull/9) ([aaronbbrown](https://github.com/aaronbbrown))
+- A few Modulefile corrections [\#8](https://github.com/ajjahn/puppet-dns/pull/8) ([aaronbbrown](https://github.com/aaronbbrown))
+- Changed single quotes to doubles [\#7](https://github.com/ajjahn/puppet-dns/pull/7) ([zodeus](https://github.com/zodeus))
+- .IN-ADDR.ARPA is missing when a PTR record is created with an A record [\#2](https://github.com/ajjahn/puppet-dns/pull/2) ([guillaumerose](https://github.com/guillaumerose))
+- Fix bug in mx record [\#1](https://github.com/ajjahn/puppet-dns/pull/1) ([dvigueras](https://github.com/dvigueras))
+
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Puppet DNS (BIND9) Module
 
 [![Build Status](https://travis-ci.org/ajjahn/puppet-dns.png?branch=master)](https://travis-ci.org/ajjahn/puppet-dns)
+[![Puppet Forge](https://img.shields.io/puppetforge/v/ajjahn/dns.svg)](https://forge.puppetlabs.com/ajjahn/dns)
+[![Puppet Forge](https://img.shields.io/puppetforge/f/ajjahn/dns.svg)](https://forge.puppetlabs.com/ajjahn/dns)
+
 
 Module for provisioning DNS (bind9)
 
@@ -187,6 +190,17 @@ Note: This module is a merge of the work from the following authors:
 * [ajjahn](https://github.com/ajjahn/puppet-dns)
 * [Danzilio](https://github.com/danzilio)
 * [solarkennedy](https://github.com/solarkennedy)
+
+## Making a Release
+
+This example is for a `minor` release. Optionally pick `full`, `major`, or `patch`.
+
+* `bundle install --with development --path vendor/bundle` # Get development gems for puppet-blacksmith
+* [optional] `github_changelog_generator --future-release $(bundle exec rake module:version:next:minor)`
+* `bundle exec rake module:bump_commit:minor`
+* `bundle exec rake module:tag`
+* `git push origin HEAD --tags`
+* Let travis deploy to the forge
 
 ## License
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ajjahn-dns",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "author": "Adam Jahn",
   "summary": "Module for provisioning DNS (bind9)",
   "license": "Apache-2.0",


### PR DESCRIPTION
Closes #177. Primary reviewer: @ajjahn 

I've tested this procedure on some other personal modules. It does work.

See the instructions for how to add an encrypted password and see if the docs on how to make a release are sane. (It is mostly splitting up the normal blacksmith steps and letting travis do the final "module:push" step)

Our travis matrix is pretty complex, and you only want one one travis target to deploy. Instead of a matrix with excludes we could do an include matrix:
https://github.com/voxpupuli/puppet-corosync/blob/master/.travis.yml#L17-L65
But in general we could probably reduce how complex the matrix is. 
