### PR TITLE
Disable case sensitivity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pkg
 log/
 spec/fixtures/modules/
 /*.lock
+spec/fixtures/manifests/site.pp

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ node 'server.example.com' {
   }
 
   # Reverse Zone
-  dns::zone { '1.168.192.IN-ADDR.ARPA':
+  dns::zone { '1.168.192.in-addr.arpa':
     soa         => 'ns1.example.com',
     soa_email   => 'admin.example.com',
     nameservers => ['ns1']

--- a/manifests/record/ns.pp
+++ b/manifests/record/ns.pp
@@ -22,7 +22,7 @@ define dns::record::ns (
   if $check_parameter_reverse != 'reverse' and $check_parameter_reverse != true and $zone =~ /^[0-9\.]+$/ {
     fail("Define[dns::record::ns]: NS zone ${zone} must be a valid domain name.")
   }
-  if ( $check_parameter_reverse == 'reverse' or $check_parameter_reverse == true ) and $zone !~ /^((25[0-5]\.|2[0-4][0-9]\.|[01]?[0-9][0-9]?\.){2}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1}|(25[0-5]\.|2[0-4][0-9]\.|[01]?[0-9][0-9]?\.){1}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1}|(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1})$/ {
+  if ( $check_parameter_reverse == 'reverse' or $check_parameter_reverse == true ) and "${zone}." !~ /^((25[0-5]\.|2[0-4][0-9]\.|[01]?[0-9][0-9]?\.){1,3})$/ {
     fail("Define[dns::record::ns]: NS zone ${zone} PTR, when parameter 'reverse' of zone '${zone}' is not false, must be included octets with separator dot!")
   }
   # Highest label (top-level domain) must be alphabetic

--- a/manifests/record/ns.pp
+++ b/manifests/record/ns.pp
@@ -14,11 +14,19 @@ define dns::record::ns (
   validate_string($data)
   validate_string($host)
 
-  if !is_domain_name($zone) or $zone =~ /^[0-9\.]+$/ {
+  # Check corrected ns zone
+  $check_parameter_reverse = getparam(Dns::Zone[$zone], 'reverse')
+  if $check_parameter_reverse != 'reverse' and $check_parameter_reverse != true and !is_domain_name($zone) {
     fail("Define[dns::record::ns]: NS zone ${zone} must be a valid domain name.")
   }
+  if $check_parameter_reverse != 'reverse' and $check_parameter_reverse != true and $zone =~ /^[0-9\.]+$/ {
+    fail("Define[dns::record::ns]: NS zone ${zone} must be a valid domain name.")
+  }
+  if ( $check_parameter_reverse == 'reverse' or $check_parameter_reverse == true ) and $zone !~ /^((25[0-5]\.|2[0-4][0-9]\.|[01]?[0-9][0-9]?\.){2}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1}|(25[0-5]\.|2[0-4][0-9]\.|[01]?[0-9][0-9]?\.){1}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1}|(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1})$/ {
+    fail("Define[dns::record::ns]: NS zone ${zone} PTR, when parameter 'reverse' of zone '${zone}' is not false, must be included octets with separator dot!")
+  }
   # Highest label (top-level domain) must be alphabetic
-  if $zone =~ /\./ and $zone !~ /\.[A-Za-z]+$/ {
+  if $check_parameter_reverse != 'reverse' and $check_parameter_reverse != true and $zone =~ /\./ and $zone !~ /\.[A-Za-z]+$/ {
     fail("Define[dns::record::ns]: NS zone ${zone} must be a valid domain name.")
   }
   # RR data must be a valid hostname, not entirely numeric values

--- a/manifests/record/ptr/by_ip.pp
+++ b/manifests/record/ptr/by_ip.pp
@@ -139,7 +139,7 @@ define dns::record::ptr::by_ip (
     $reverse_zone = $reverse_class_a_zone
     $octet = $class_a_host
   } else {
-    notify { "PTR record for ip-address '${ip}' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '${ip}'!": }
+    notify { "PTR record for IP address '${ip}' not created: No `dns::zone` resource declared for the class A, B, or C subnet of this IP address.": }
   }
 
   if $reverse_zone and $octet {

--- a/manifests/record/ptr/by_ip.pp
+++ b/manifests/record/ptr/by_ip.pp
@@ -34,9 +34,9 @@
 # turns into:
 #
 # @example
-#     dns::record::ptr { '42.128.168.192.IN-ADDR.ARPA':
+#     dns::record::ptr { '42.128.168.192.in-addr.arpa':
 #       host => '42' ,
-#       zone => '128.168.192.IN-ADDR.ARPA' ,
+#       zone => '128.168.192.in-addr.arpa' ,
 #       data => 'server.example.com' ,
 #     }
 #
@@ -50,21 +50,21 @@
 # turns into:
 #
 # @example
-#     dns::record::ptr { '68.128.168.192.IN-ADDR.ARPA':
+#     dns::record::ptr { '68.128.168.192.in-addr.arpa':
 #       host => '68' ,
-#       zone => '128.168.192.IN-ADDR.ARPA' ,
+#       zone => '128.168.192.in-addr.arpa' ,
 #       data => 'multihomed-server.example.com' ,
 #
 # @example
-#     dns::record::ptr { '69.128.168.192.IN-ADDR.ARPA':
+#     dns::record::ptr { '69.128.168.192.in-addr.arpa':
 #       host => '69' ,
-#       zone => '128.168.192.IN-ADDR.ARPA' ,
+#       zone => '128.168.192.in-addr.arpa' ,
 #       data => 'multihomed-server.example.com' ,
 #
 # @example
-#     dns::record::ptr { '70.128.168.192.IN-ADDR.ARPA':
+#     dns::record::ptr { '70.128.168.192.in-addr.arpa':
 #       host => '70' ,
-#       zone => '128.168.192.IN-ADDR.ARPA' ,
+#       zone => '128.168.192.in-addr.arpa' ,
 #       data => 'multihomed-server.example.com' ,
 #     }
 
@@ -76,36 +76,78 @@ define dns::record::ptr::by_ip (
 
   # split the IP address up into three host/zone pairs based on class A, B, or C splits:
   # For IP address A.B.C.D,
-  # class C => host D / zone C.B.A.IN-ADDR.ARPA
-  # class B => host D.C / zone B.A.IN-ADDR.ARPA
-  # class A => host D.C.B / zone A.IN-ADDR.ARPA
-  $class_c_zone = inline_template('<%= @ip.split(".").reverse()[1..3].join(".") %>.IN-ADDR.ARPA')
+  # class C => host D / zone C.B.A.in-addr.arpa
+  # class B => host D.C / zone B.A.in-addr.arpa
+  # class A => host D.C.B / zone A.in-addr.arpa
+  $class_c_zone = inline_template('<%= @ip.split(".").reverse()[1..3].join(".") %>.in-addr.arpa')
   $class_c_host = inline_template('<%= @ip.split(".").reverse()[0..0].join(".") %>')
-  $class_b_zone = inline_template('<%= @ip.split(".").reverse()[2..3].join(".") %>.IN-ADDR.ARPA')
+  $class_b_zone = inline_template('<%= @ip.split(".").reverse()[2..3].join(".") %>.in-addr.arpa')
   $class_b_host = inline_template('<%= @ip.split(".").reverse()[0..1].join(".") %>')
-  $class_a_zone = inline_template('<%= @ip.split(".").reverse()[3..3].join(".") %>.IN-ADDR.ARPA')
+  $class_a_zone = inline_template('<%= @ip.split(".").reverse()[3..3].join(".") %>.in-addr.arpa')
   $class_a_host = inline_template('<%= @ip.split(".").reverse()[0..2].join(".") %>')
+
+  # Zone names reverse is true
+  $reverse_true_class_c_zone = regsubst($class_c_zone, '\.in-addr\.arpa', '')
+  $reverse_true_class_b_zone = regsubst($class_b_zone, '\.in-addr\.arpa', '')
+  $reverse_true_class_a_zone = regsubst($class_a_zone, '\.in-addr\.arpa', '')
+
+  # Zone names reverse is 'reverse'
+  $reverse_class_c_zone = regsubst($ip, '^(\d+)\.(\d+)\.(\d+)\.(\d+)$','\1.\2.\3')
+  $reverse_class_b_zone = regsubst($ip, '^(\d+)\.(\d+)\.(\d+)\.(\d+)$', '\1.\2')
+  $reverse_class_a_zone = regsubst($ip, '^(\d+)\.(\d+)\.(\d+)\.(\d+)$', '\1')
 
   # choose the most specific defined reverse zone file (class C, then B, then A).
   # Default to class C if none are defined.
+
+  # Class C
+  # Conditions parameter reverse is false
   if defined(Dns::Zone[$class_c_zone]) {
     $reverse_zone = $class_c_zone
     $octet = $class_c_host
+  # Conditions (C.B.A|B.A|A) and parameter reverse is true
+  } elsif defined(Dns::Zone[$reverse_true_class_c_zone]) and getparam(Dns::Zone[$reverse_true_class_c_zone], 'reverse') == true {
+    $reverse_zone = $reverse_true_class_c_zone
+    $octet = $class_c_host
+  # Conditions (A.B.C|A.B|A) and parameter reverse is 'reverse'
+  } elsif defined(Dns::Zone[$reverse_class_c_zone]) and getparam(Dns::Zone[$reverse_class_c_zone], 'reverse') == 'reverse' {
+    $reverse_zone = $reverse_class_c_zone
+    $octet = $class_c_host
+  # Class B
+  # Conditions parameter reverse is false
   } elsif defined(Dns::Zone[$class_b_zone]) {
     $reverse_zone = $class_b_zone
     $octet = $class_b_host
+  # Conditions (C.B.A|B.A|A) and parameter reverse is true
+  } elsif defined(Dns::Zone[$reverse_true_class_b_zone]) and getparam(Dns::Zone[$reverse_true_class_b_zone], 'reverse') == true {
+    $reverse_zone = $reverse_true_class_b_zone
+    $octet = $class_b_host
+  # Conditions (A.B.C|A.B|A) and parameter reverse is 'reverse'
+  } elsif defined(Dns::Zone[$reverse_class_b_zone]) and getparam(Dns::Zone[$reverse_class_b_zone], 'reverse') == 'reverse' {
+    $reverse_zone = $reverse_class_b_zone
+    $octet = $class_b_host
+  # Class A
+  # Conditions parameter reverse is false
   } elsif defined(Dns::Zone[$class_a_zone]) {
     $reverse_zone = $class_a_zone
     $octet = $class_a_host
+  # Conditions (C.B.A|B.A|A) and parameter reverse is true
+  } elsif defined(Dns::Zone[$reverse_true_class_a_zone]) and getparam(Dns::Zone[$reverse_true_class_a_zone], 'reverse') == true {
+    $reverse_zone = $reverse_true_class_a_zone
+    $octet = $class_a_host
+  # Conditions (A.B.C|A.B|A) and parameter reverse is 'reverse'
+  } elsif defined(Dns::Zone[$reverse_class_a_zone]) and getparam(Dns::Zone[$reverse_class_a_zone], 'reverse') == 'reverse' {
+    $reverse_zone = $reverse_class_a_zone
+    $octet = $class_a_host
   } else {
-    $reverse_zone = $class_c_zone
-    $octet = $class_c_host
+    notify { "PTR record for ip-address '${ip}' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '${ip}'!": }
   }
 
-  dns::record::ptr { "${octet}.${reverse_zone}":
-    host => $octet,
-    zone => $reverse_zone,
-    ttl  => $ttl ,
-    data => "${host}.${zone}"
+  if $reverse_zone and $octet {
+    dns::record::ptr { "${octet}.${reverse_zone}":
+      host => $octet,
+      zone => $reverse_zone,
+      ttl  => $ttl ,
+      data => "${host}.${zone}"
+    }
   }
 }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -189,25 +189,25 @@ define dns::zone (
 
   case $reverse {
     'reverse': {
-      if $name !~ /^((25[0-5]\.|2[0-4][0-9]\.|[01]?[0-9][0-9]?\.){2}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1}|(25[0-5]\.|2[0-4][0-9]\.|[01]?[0-9][0-9]?\.){1}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1}|(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1})$/ {
+      if "${name}." !~ /^((25[0-5]\.|2[0-4][0-9]\.|[01]?[0-9][0-9]?\.){1,3})$/ {
         fail("Name zone with parameter reverse equal 'reverse' must be included only one, two or three first octets! Example: '192.168'!")
       }
       $zone = join(reverse(split("arpa.in-addr.${name}", '\.')), '.')
     }
     true: {
-      if $name !~ /^((25[0-5]\.|2[0-4][0-9]\.|[01]?[0-9][0-9]?\.){2}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1}|(25[0-5]\.|2[0-4][0-9]\.|[01]?[0-9][0-9]?\.){1}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1}|(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1})$/ {
+      if "${name}." !~ /^((25[0-5]\.|2[0-4][0-9]\.|[01]?[0-9][0-9]?\.){1,3})$/ {
         fail("Name zone with parameter reverse equal true must be included only reversed one, two or three first octets! Example: '168.192'!")
       }
       $zone = "${name}.in-addr.arpa"
     }
     default: {
       if !is_domain_name($name) {
-        fail("Name zone with parameter reverse equal false must be valid domain name! Example: 'exampe.com'!")
+        fail("Name zone with parameter reverse equal false must be valid domain name! Example: 'example.com'!")
       }
       $zone = $name
       if $name =~ /\.in-addr\.arpa$/ {
-        $name_zone_reverse_true    = regsubst($name, '\.in-addr\.arpa$', '')
-        if $name_zone_reverse_true !~ /^((25[0-5]\.|2[0-4][0-9]\.|[01]?[0-9][0-9]?\.){2}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1}|(25[0-5]\.|2[0-4][0-9]\.|[01]?[0-9][0-9]?\.){1}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1}|(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?){1})$/ {
+        $name_zone_reverse_true = regsubst($name, '\.in-addr\.arpa$', '')
+        if "${name_zone_reverse_true}." !~ /^((25[0-5]\.|2[0-4][0-9]\.|[01]?[0-9][0-9]?\.){1,3})$/ {
           fail("Name zone with parameter reverse equal false must be included only reversed one, two or three first octets and 'in-addr.arpa'! Example: '168.192.in-addr.arpa'!")
         }
       }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -201,7 +201,7 @@ define dns::zone (
       $zone = "${name}.in-addr.arpa"
     }
     default: {
-      unless is_domain_name($name) {
+      if !is_domain_name($name) {
         fail("Name zone with parameter reverse equal false must be valid domain name! Example: 'exampe.com'!")
       }
       $zone = $name

--- a/spec/defines/dns__record__a_spec.rb
+++ b/spec/defines/dns__record__a_spec.rb
@@ -25,7 +25,7 @@ describe 'dns::record::a', :type => :define do
     } end
     it { should_not raise_error }
     it { should contain_concat__fragment('db.example.com.atest,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.42$/) }
-    it { should contain_notify("PTR record for ip-address '192.168.128.42' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.42'!")}
+    it { should contain_notify("PTR record for IP address '192.168.128.42' not created: No `dns::zone` resource declared for the class A, B, or C subnet of this IP address.")}
   end
 
   context 'passing a single ip address with ptr=>all' do
@@ -37,7 +37,7 @@ describe 'dns::record::a', :type => :define do
     } end
     it { should_not raise_error }
     it { should contain_concat__fragment('db.example.com.atest,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.42$/) }
-    it { should contain_notify("PTR record for ip-address '192.168.128.42' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.42'!")}
+    it { should contain_notify("PTR record for IP address '192.168.128.42' not created: No `dns::zone` resource declared for the class A, B, or C subnet of this IP address.")}
   end
 
   context 'passing multiple ip addresses with ptr=>false' do
@@ -61,9 +61,9 @@ describe 'dns::record::a', :type => :define do
     } end
     it { should_not raise_error }
     it { should contain_concat__fragment('db.example.com.atest,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.68\natest\s+IN\s+A\s+192\.168\.128\.69\natest\s+IN\s+A\s+192\.168\.128\.70$/) }
-    it { should contain_notify("PTR record for ip-address '192.168.128.68' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.68'!")}
-    it { should_not contain_notify("PTR record for ip-address '192.168.128.69' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.69'!")}
-    it { should_not contain_notify("PTR record for ip-address '192.168.128.70' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.70'!")}
+    it { should contain_notify("PTR record for IP address '192.168.128.68' not created: No `dns::zone` resource declared for the class A, B, or C subnet of this IP address.")}
+    it { should_not contain_notify("PTR record for IP address '192.168.128.69' not created: No `dns::zone` resource declared for the class A, B, or C subnet of this IP address.")}
+    it { should_not contain_notify("PTR record for IP address '192.168.128.70' not created: No `dns::zone` resource declared for the class A, B, or C subnet of this IP address.")}
   end
 
   context 'passing multiple ip addresses with ptr=>all' do
@@ -75,9 +75,9 @@ describe 'dns::record::a', :type => :define do
     } end
     it { should_not raise_error }
     it { should contain_concat__fragment('db.example.com.atest,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.68\natest\s+IN\s+A\s+192\.168\.128\.69\natest\s+IN\s+A\s+192\.168\.128\.70$/) }
-    it { should contain_notify("PTR record for ip-address '192.168.128.68' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.68'!")}
-    it { should contain_notify("PTR record for ip-address '192.168.128.69' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.69'!")}
-    it { should contain_notify("PTR record for ip-address '192.168.128.70' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.70'!")}
+    it { should contain_notify("PTR record for IP address '192.168.128.68' not created: No `dns::zone` resource declared for the class A, B, or C subnet of this IP address.")}
+    it { should contain_notify("PTR record for IP address '192.168.128.69' not created: No `dns::zone` resource declared for the class A, B, or C subnet of this IP address.")}
+    it { should contain_notify("PTR record for IP address '192.168.128.70' not created: No `dns::zone` resource declared for the class A, B, or C subnet of this IP address.")}
   end
 
   context 'passing ptr=>first with class A network defined with parameter reverse is false (default)' do

--- a/spec/defines/dns__record__a_spec.rb
+++ b/spec/defines/dns__record__a_spec.rb
@@ -13,19 +13,19 @@ describe 'dns::record::a', :type => :define do
     } end
     it { should_not raise_error }
     it { should contain_concat__fragment('db.example.com.atest,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.42$/) }
-    it { should_not contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.42.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record') }
+    it { should_not contain_concat__fragment('db.128.168.192.in-addr.arpa.42.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record') }
   end
 
-  context 'passing a single ip address with ptr=>true' do
+  context 'passing a single ip address with ptr=>first' do
     let :params do {
         :host => 'atest',
         :zone => 'example.com',
         :data => '192.168.128.42',
-        :ptr => true,
+        :ptr => 'first',
     } end
     it { should_not raise_error }
     it { should contain_concat__fragment('db.example.com.atest,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.42$/) }
-    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.42.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^42\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_notify("PTR record for ip-address '192.168.128.42' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.42'!")}
   end
 
   context 'passing a single ip address with ptr=>all' do
@@ -37,7 +37,7 @@ describe 'dns::record::a', :type => :define do
     } end
     it { should_not raise_error }
     it { should contain_concat__fragment('db.example.com.atest,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.42$/) }
-    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.42.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^42\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_notify("PTR record for ip-address '192.168.128.42' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.42'!")}
   end
 
   context 'passing multiple ip addresses with ptr=>false' do
@@ -49,19 +49,21 @@ describe 'dns::record::a', :type => :define do
     } end
     it { should_not raise_error }
     it { should contain_concat__fragment('db.example.com.atest,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.68\natest\s+IN\s+A\s+192\.168\.128\.69\natest\s+IN\s+A\s+192\.168\.128\.70$/) }
-    it { should_not contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.68.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record') }
+    it { should_not contain_concat__fragment('db.128.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record') }
   end
 
-  context 'passing multiple ip addresses with ptr=>true' do
+  context 'passing multiple ip addresses with ptr=>first' do
     let :params do {
         :host => 'atest',
         :zone => 'example.com',
         :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
-        :ptr => true,
+        :ptr => 'first',
     } end
     it { should_not raise_error }
     it { should contain_concat__fragment('db.example.com.atest,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.68\natest\s+IN\s+A\s+192\.168\.128\.69\natest\s+IN\s+A\s+192\.168\.128\.70$/) }
-    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.68.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_notify("PTR record for ip-address '192.168.128.68' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.68'!")}
+    it { should_not contain_notify("PTR record for ip-address '192.168.128.69' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.69'!")}
+    it { should_not contain_notify("PTR record for ip-address '192.168.128.70' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.70'!")}
   end
 
   context 'passing multiple ip addresses with ptr=>all' do
@@ -73,12 +75,60 @@ describe 'dns::record::a', :type => :define do
     } end
     it { should_not raise_error }
     it { should contain_concat__fragment('db.example.com.atest,A,example.com.record').with_content(/^atest\s+IN\s+A\s+192\.168\.128\.68\natest\s+IN\s+A\s+192\.168\.128\.69\natest\s+IN\s+A\s+192\.168\.128\.70$/) }
-    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.68.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
-    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.69.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
-    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.70.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_notify("PTR record for ip-address '192.168.128.68' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.68'!")}
+    it { should contain_notify("PTR record for ip-address '192.168.128.69' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.69'!")}
+    it { should contain_notify("PTR record for ip-address '192.168.128.70' not creates! Not found declareted define Dns::Zone of 'A', 'B' or 'C' network classes for ip-address '192.168.128.70'!")}
   end
 
-  context 'passing ptr=>true with class A network defined' do
+  context 'passing ptr=>first with class A network defined with parameter reverse is false (default)' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192.in-addr.arpa": }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,192.in-addr.arpa.record').with_content(/^68\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,192.in-addr.arpa.record').with_content(/^69\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,192.in-addr.arpa.record').with_content(/^70\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class B network defined with parameter reverse is false (default)' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "168.192.in-addr.arpa": }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,168.192.in-addr.arpa.record').with_content(/^68\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.168.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,168.192.in-addr.arpa.record').with_content(/^69\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.168.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,168.192.in-addr.arpa.record').with_content(/^70\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class C network defined with parameter reverse is false (default)' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "128.168.192.in-addr.arpa": }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A network defined with parameter reverse is false (default)' do
     let :params do {
         :host => 'atest',
         :zone => 'example.com',
@@ -86,13 +136,15 @@ describe 'dns::record::a', :type => :define do
         :ptr => 'all',
     } end
     let :pre_condition do [
-        'dns::zone { "192.IN-ADDR.ARPA": }',
+        'dns::zone { "192.in-addr.arpa": }',
     ] end
     it { should_not raise_error }
-    it { should contain_concat__fragment('db.192.IN-ADDR.ARPA.68.128.168.192.IN-ADDR.ARPA,PTR,192.IN-ADDR.ARPA.record').with_content(/^68\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,192.in-addr.arpa.record').with_content(/^68\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,192.in-addr.arpa.record').with_content(/^69\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,192.in-addr.arpa.record').with_content(/^70\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
   end
 
-  context 'passing ptr=>true with class B network defined' do
+  context 'passing ptr=>all with class B network defined with parameter reverse is false (default)' do
     let :params do {
         :host => 'atest',
         :zone => 'example.com',
@@ -100,13 +152,15 @@ describe 'dns::record::a', :type => :define do
         :ptr => 'all',
     } end
     let :pre_condition do [
-        'dns::zone { "168.192.IN-ADDR.ARPA": }',
+        'dns::zone { "168.192.in-addr.arpa": }',
     ] end
     it { should_not raise_error }
-    it { should contain_concat__fragment('db.168.192.IN-ADDR.ARPA.68.128.168.192.IN-ADDR.ARPA,PTR,168.192.IN-ADDR.ARPA.record').with_content(/^68\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,168.192.in-addr.arpa.record').with_content(/^68\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.168.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,168.192.in-addr.arpa.record').with_content(/^69\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.168.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,168.192.in-addr.arpa.record').with_content(/^70\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
   end
 
-  context 'passing ptr=>true with class C network defined' do
+  context 'passing ptr=>all with class C network defined with parameter reverse is false (default)' do
     let :params do {
         :host => 'atest',
         :zone => 'example.com',
@@ -114,13 +168,32 @@ describe 'dns::record::a', :type => :define do
         :ptr => 'all',
     } end
     let :pre_condition do [
-        'dns::zone { "128.168.192.IN-ADDR.ARPA": }',
+        'dns::zone { "128.168.192.in-addr.arpa": }',
     ] end
     it { should_not raise_error }
-    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.68.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
   end
 
-  context 'passing ptr=>true with class A and class B network defined' do
+  context 'passing ptr=>first with class A and class B network defined with parameter reverse is false (default)' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192.in-addr.arpa": }',
+        'dns::zone { "168.192.in-addr.arpa": }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,168.192.in-addr.arpa.record').with_content(/^68\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.168.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,168.192.in-addr.arpa.record').with_content(/^69\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.168.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,168.192.in-addr.arpa.record').with_content(/^70\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A and class B network defined with parameter reverse is false (default)' do
     let :params do {
         :host => 'atest',
         :zone => 'example.com',
@@ -128,14 +201,33 @@ describe 'dns::record::a', :type => :define do
         :ptr => 'all',
     } end
     let :pre_condition do [
-        'dns::zone { "192.IN-ADDR.ARPA": }',
-        'dns::zone { "168.192.IN-ADDR.ARPA": }',
+        'dns::zone { "192.in-addr.arpa": }',
+        'dns::zone { "168.192.in-addr.arpa": }',
     ] end
     it { should_not raise_error }
-    it { should contain_concat__fragment('db.168.192.IN-ADDR.ARPA.68.128.168.192.IN-ADDR.ARPA,PTR,168.192.IN-ADDR.ARPA.record').with_content(/^68\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,168.192.in-addr.arpa.record').with_content(/^68\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.168.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,168.192.in-addr.arpa.record').with_content(/^69\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.168.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,168.192.in-addr.arpa.record').with_content(/^70\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
   end
 
-  context 'passing ptr=>true with class A and class C network defined' do
+  context 'passing ptr=>first with class A and class C network defined with parameter reverse is false (default)' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192.in-addr.arpa": }',
+        'dns::zone { "128.168.192.in-addr.arpa": }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A and class C network defined with parameter reverse is false (default)' do
     let :params do {
         :host => 'atest',
         :zone => 'example.com',
@@ -143,14 +235,33 @@ describe 'dns::record::a', :type => :define do
         :ptr => 'all',
     } end
     let :pre_condition do [
-        'dns::zone { "192.IN-ADDR.ARPA": }',
-        'dns::zone { "128.168.192.IN-ADDR.ARPA": }',
+        'dns::zone { "192.in-addr.arpa": }',
+        'dns::zone { "128.168.192.in-addr.arpa": }',
     ] end
     it { should_not raise_error }
-    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.68.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
   end
 
-  context 'passing ptr=>true with class B and class C network defined' do
+  context 'passing ptr=>first with class B and class C network defined with parameter reverse is false (default)' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "168.192.in-addr.arpa": }',
+        'dns::zone { "128.168.192.in-addr.arpa": }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class B and class C network defined with parameter reverse is false (default)' do
     let :params do {
         :host => 'atest',
         :zone => 'example.com',
@@ -158,14 +269,34 @@ describe 'dns::record::a', :type => :define do
         :ptr => 'all',
     } end
     let :pre_condition do [
-        'dns::zone { "168.192.IN-ADDR.ARPA": }',
-        'dns::zone { "128.168.192.IN-ADDR.ARPA": }',
+        'dns::zone { "168.192.in-addr.arpa": }',
+        'dns::zone { "128.168.192.in-addr.arpa": }',
     ] end
     it { should_not raise_error }
-    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.68.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
   end
 
-  context 'passing ptr=>true with class A, class B and class C network defined' do
+  context 'passing ptr=>first with class A, class B and class C network defined with parameter reverse is false (default)' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192.in-addr.arpa": }',
+        'dns::zone { "168.192.in-addr.arpa": }',
+        'dns::zone { "128.168.192.in-addr.arpa": }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A, class B and class C network defined with parameter reverse is false (default)' do
     let :params do {
         :host => 'atest',
         :zone => 'example.com',
@@ -173,13 +304,590 @@ describe 'dns::record::a', :type => :define do
         :ptr => 'all',
     } end
     let :pre_condition do [
-        'dns::zone { "192.IN-ADDR.ARPA": }',
-        'dns::zone { "168.192.IN-ADDR.ARPA": }',
-        'dns::zone { "128.168.192.IN-ADDR.ARPA": }',
+        'dns::zone { "192.in-addr.arpa": }',
+        'dns::zone { "168.192.in-addr.arpa": }',
+        'dns::zone { "128.168.192.in-addr.arpa": }',
     ] end
     it { should_not raise_error }
-    it { should contain_concat__fragment('db.128.168.192.IN-ADDR.ARPA.68.128.168.192.IN-ADDR.ARPA,PTR,128.168.192.IN-ADDR.ARPA.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class A network defined with parameter reverse is true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.68.128.168.192,PTR,192.record').with_content(/^68\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.69.128.168.192,PTR,192.record').with_content(/^69\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.70.128.168.192,PTR,192.record').with_content(/^70\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class B network defined with parameter reverse is true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.168.192.68.128.168.192,PTR,168.192.record').with_content(/^68\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.168.192.69.128.168.192,PTR,168.192.record').with_content(/^69\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.168.192.70.128.168.192,PTR,168.192.record').with_content(/^70\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class C network defined with parameter reverse is true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "128.168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.68.128.168.192,PTR,128.168.192.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.69.128.168.192,PTR,128.168.192.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.70.128.168.192,PTR,128.168.192.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A network defined with parameter reverse is true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.68.128.168.192,PTR,192.record').with_content(/^68\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.69.128.168.192,PTR,192.record').with_content(/^69\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.70.128.168.192,PTR,192.record').with_content(/^70\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class B network defined with parameter reverse is true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.168.192.68.128.168.192,PTR,168.192.record').with_content(/^68\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.168.192.69.128.168.192,PTR,168.192.record').with_content(/^69\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.168.192.70.128.168.192,PTR,168.192.record').with_content(/^70\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class C network defined with parameter reverse is true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "128.168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.68.128.168.192,PTR,128.168.192.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.69.128.168.192,PTR,128.168.192.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.70.128.168.192,PTR,128.168.192.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class A and class B network defined with parameter reverse is true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => true, }',
+        'dns::zone { "168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.168.192.68.128.168.192,PTR,168.192.record').with_content(/^68\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.168.192.69.128.168.192,PTR,168.192.record').with_content(/^69\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.168.192.70.128.168.192,PTR,168.192.record').with_content(/^70\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A and class B network defined with parameter reverse is true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => true, }',
+        'dns::zone { "168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.168.192.68.128.168.192,PTR,168.192.record').with_content(/^68\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.168.192.69.128.168.192,PTR,168.192.record').with_content(/^69\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.168.192.70.128.168.192,PTR,168.192.record').with_content(/^70\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class A and class C network defined with parameter reverse is true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => true, }',
+        'dns::zone { "128.168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.68.128.168.192,PTR,128.168.192.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.69.128.168.192,PTR,128.168.192.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.70.128.168.192,PTR,128.168.192.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A and class C network defined with parameter reverse is true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => true, }',
+        'dns::zone { "128.168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.68.128.168.192,PTR,128.168.192.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.69.128.168.192,PTR,128.168.192.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.70.128.168.192,PTR,128.168.192.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class B and class C network defined with parameter reverse is true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "168.192": reverse => true, }',
+        'dns::zone { "128.168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.68.128.168.192,PTR,128.168.192.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.69.128.168.192,PTR,128.168.192.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.70.128.168.192,PTR,128.168.192.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class B and class C network defined with parameter reverse is true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "168.192": reverse => true, }',
+        'dns::zone { "128.168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.68.128.168.192,PTR,128.168.192.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.69.128.168.192,PTR,128.168.192.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.70.128.168.192,PTR,128.168.192.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class A, class B and class C network defined with parameter reverse is true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => true, }',
+        'dns::zone { "168.192": reverse => true, }',
+        'dns::zone { "128.168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.68.128.168.192,PTR,128.168.192.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.69.128.168.192,PTR,128.168.192.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.70.128.168.192,PTR,128.168.192.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A, class B and class C network defined with parameter reverse is true' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => true, }',
+        'dns::zone { "168.192": reverse => true, }',
+        'dns::zone { "128.168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.68.128.168.192,PTR,128.168.192.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.69.128.168.192,PTR,128.168.192.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.70.128.168.192,PTR,128.168.192.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class A network defined with parameter reverse is "reverse"' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.68.128.168.192,PTR,192.record').with_content(/^68\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.69.128.168.192,PTR,192.record').with_content(/^69\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.70.128.168.192,PTR,192.record').with_content(/^70\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class B network defined with parameter reverse is "reverse"' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192.168": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.68.128.192.168,PTR,192.168.record').with_content(/^68\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.168.69.128.192.168,PTR,192.168.record').with_content(/^69\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.168.70.128.192.168,PTR,192.168.record').with_content(/^70\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class C network defined with parameter reverse is "reverse"' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192.168.128": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.128.68.192.168.128,PTR,192.168.128.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.168.128.69.192.168.128,PTR,192.168.128.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.168.128.70.192.168.128,PTR,192.168.128.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A network defined with parameter reverse is "reverse"' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.68.128.168.192,PTR,192.record').with_content(/^68\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.69.128.168.192,PTR,192.record').with_content(/^69\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.70.128.168.192,PTR,192.record').with_content(/^70\.128\.168\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class B network defined with parameter reverse is "reverse"' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192.168": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.68.128.192.168,PTR,192.168.record').with_content(/^68\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.168.69.128.192.168,PTR,192.168.record').with_content(/^69\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.168.70.128.192.168,PTR,192.168.record').with_content(/^70\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class C network defined with parameter reverse is "reverse"' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192.168.128": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.128.68.192.168.128,PTR,192.168.128.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.168.128.69.192.168.128,PTR,192.168.128.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.168.128.70.192.168.128,PTR,192.168.128.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class A and class B network defined with parameter reverse is "reverse"' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => "reverse", }',
+        'dns::zone { "192.168": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.68.128.192.168,PTR,192.168.record').with_content(/^68\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.168.69.128.192.168,PTR,192.168.record').with_content(/^69\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.168.70.128.192.168,PTR,192.168.record').with_content(/^70\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A and class B network defined with parameter reverse is "reverse"' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => "reverse", }',
+        'dns::zone { "192.168": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.68.128.192.168,PTR,192.168.record').with_content(/^68\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.168.69.128.192.168,PTR,192.168.record').with_content(/^69\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.168.70.128.192.168,PTR,192.168.record').with_content(/^70\.128\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class A and class C network defined with parameter reverse is "reverse"' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => "reverse", }',
+        'dns::zone { "192.168.128": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.128.68.192.168.128,PTR,192.168.128.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.168.128.69.192.168.128,PTR,192.168.128.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.168.128.70.192.168.128,PTR,192.168.128.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A and class C network defined with parameter reverse is "reverse"' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => "reverse", }',
+        'dns::zone { "192.168.128": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.128.68.192.168.128,PTR,192.168.128.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.168.128.69.192.168.128,PTR,192.168.128.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.168.128.70.192.168.128,PTR,192.168.128.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class B and class C network defined with parameter reverse is "reverse"' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192.168": reverse => "reverse", }',
+        'dns::zone { "192.168.128": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.128.68.192.168.128,PTR,192.168.128.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.168.128.69.192.168.128,PTR,192.168.128.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.168.128.70.192.168.128,PTR,192.168.128.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class B and class C network defined with parameter reverse is "reverse"' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192.168": reverse => "reverse", }',
+        'dns::zone { "192.168.128": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.128.68.192.168.128,PTR,192.168.128.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.168.128.69.192.168.128,PTR,192.168.128.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.168.128.70.192.168.128,PTR,192.168.128.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class A, class B and class C network defined with parameter reverse is "reverse"' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => "reverse", }',
+        'dns::zone { "192.168": reverse => "reverse", }',
+        'dns::zone { "192.168.128": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.128.68.192.168.128,PTR,192.168.128.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.168.128.69.192.168.128,PTR,192.168.128.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.168.128.70.192.168.128,PTR,192.168.128.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A, class B and class C network defined with parameter reverse is "reverse"' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => "reverse", }',
+        'dns::zone { "192.168": reverse => "reverse", }',
+        'dns::zone { "192.168.128": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.128.68.192.168.128,PTR,192.168.128.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.168.128.69.192.168.128,PTR,192.168.128.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.168.128.70.192.168.128,PTR,192.168.128.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class A (defined with parameter reverse is false), class B (defined with parameter reverse is true) and class C (defined with parameter reverse is "reverse") network' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192.in-addr.arpa": }',
+        'dns::zone { "168.192": reverse => true, }',
+        'dns::zone { "192.168.128": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.128.68.192.168.128,PTR,192.168.128.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.168.128.69.192.168.128,PTR,192.168.128.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.192.168.128.70.192.168.128,PTR,192.168.128.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A (defined with parameter reverse is false), class B (defined with parameter reverse is true) and class C (defined with parameter reverse is "reverse") network' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192.in-addr.arpa": }',
+        'dns::zone { "168.192": reverse => true, }',
+        'dns::zone { "192.168.128": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.128.68.192.168.128,PTR,192.168.128.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.168.128.69.192.168.128,PTR,192.168.128.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.192.168.128.70.192.168.128,PTR,192.168.128.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class A (defined with parameter reverse is "reverse"), class B (defined with parameter reverse is false) and class C (defined with parameter reverse is true) network' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => "reverse", }',
+        'dns::zone { "168.192.in-addr.arpa": }',
+        'dns::zone { "128.168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.68.128.168.192,PTR,128.168.192.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.69.128.168.192,PTR,128.168.192.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.70.128.168.192,PTR,128.168.192.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A (defined with parameter reverse is "reverse"), class B (defined with parameter reverse is false) and class C (defined with parameter reverse is true) network' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => "reverse", }',
+        'dns::zone { "168.192.in-addr.arpa": }',
+        'dns::zone { "128.168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.68.128.168.192,PTR,128.168.192.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.69.128.168.192,PTR,128.168.192.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.70.128.168.192,PTR,128.168.192.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>first with class A (defined with parameter reverse is true), class B (defined with parameter reverse is "reverse") and class C (defined with parameter reverse is false) network' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'first',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => true, }',
+        'dns::zone { "192.168": reverse => "reverse", }',
+        'dns::zone { "128.168.192.in-addr.arpa": }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should_not contain_concat__fragment('db.128.168.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+  end
+
+  context 'passing ptr=>all with class A (defined with parameter reverse is true), class B (defined with parameter reverse is "reverse") and class C (defined with parameter reverse is false) network' do
+    let :params do {
+        :host => 'atest',
+        :zone => 'example.com',
+        :data => [ '192.168.128.68', '192.168.128.69', '192.168.128.70' ],
+        :ptr => 'all',
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => true, }',
+        'dns::zone { "192.168": reverse => "reverse", }',
+        'dns::zone { "128.168.192.in-addr.arpa": }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.68.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^68\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.69.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^69\s+IN\s+PTR\s+atest\.example\.com\.$/) }
+    it { should contain_concat__fragment('db.128.168.192.in-addr.arpa.70.128.168.192.in-addr.arpa,PTR,128.168.192.in-addr.arpa.record').with_content(/^70\s+IN\s+PTR\s+atest\.example\.com\.$/) }
   end
 
 end
-

--- a/spec/defines/dns__record__aliases.spec.rb
+++ b/spec/defines/dns__record__aliases.spec.rb
@@ -159,25 +159,25 @@ describe 'dns::record::ptr', :type => :define do
 
   context 'letting the host be defined by the resource name' do
     let :params do {
-        :zone => '0.0.127.IN-ADDR.ARPA',
+        :zone => '0.0.127.in-addr.arpa',
         :title => '1' ,
         :data => 'localhost',
     } end
     it { should_not raise_error }
-    it { should contain_concat__fragment('db.0.0.127.IN-ADDR.ARPA.1,PTR,0.0.127.IN-ADDR.ARPA.record')
+    it { should contain_concat__fragment('db.0.0.127.in-addr.arpa.1,PTR,0.0.127.in-addr.arpa.record')
       .with_content(/^1\s+IN\s+PTR\s+localhost\.$/)
      }
   end
 
   context 'assigning a different host than the resource name' do
     let :params do {
-        :zone => '0.0.127.IN-ADDR.ARPA',
+        :zone => '0.0.127.in-addr.arpa',
         :title => 'foo' ,
         :host => '1' ,
         :data => 'localhost',
     } end
     it { should_not raise_error }
-    it { should contain_concat__fragment('db.0.0.127.IN-ADDR.ARPA.foo,PTR,0.0.127.IN-ADDR.ARPA.record')
+    it { should contain_concat__fragment('db.0.0.127.in-addr.arpa.foo,PTR,0.0.127.in-addr.arpa.record')
       .with_content(/^1\s+IN\s+PTR\s+localhost\.$/)
      }
   end

--- a/spec/defines/dns__record__ns_spec.rb
+++ b/spec/defines/dns__record__ns_spec.rb
@@ -23,6 +23,84 @@ describe 'dns::record::ns', :type => :define do
     it { should contain_concat__fragment('db.example.com.delegated-zone,example.com,NS,ns4.jp.example.net..record').with_content(/^delegated-zone\s+IN\s+NS\s+ns4.jp.example.net\.$/) }
   end
 
+  context 'passing an explicit host for reverse zone 192 (reverse=>true)' do
+    let :params do {
+        :zone       => '192',
+        :host       => '@',
+        :data       => 'ns4.jp.example.net.'
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.@,192,NS,ns4.jp.example.net..record').with_content(/^@\s+IN\s+NS\s+ns4.jp.example.net\.$/) }
+  end
+
+  context 'passing an explicit host for reverse zone 192 (reverse=>"reverse")' do
+    let :params do {
+        :zone       => '192',
+        :host       => '@',
+        :data       => 'ns4.jp.example.net.'
+    } end
+    let :pre_condition do [
+        'dns::zone { "192": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.@,192,NS,ns4.jp.example.net..record').with_content(/^@\s+IN\s+NS\s+ns4.jp.example.net\.$/) }
+  end
+
+  context 'passing an explicit host for reverse zone 168.192 (reverse=>true)' do
+    let :params do {
+        :zone       => '168.192',
+        :host       => '@',
+        :data       => 'ns4.jp.example.net.'
+    } end
+    let :pre_condition do [
+        'dns::zone { "168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.168.192.@,168.192,NS,ns4.jp.example.net..record').with_content(/^@\s+IN\s+NS\s+ns4.jp.example.net\.$/) }
+  end
+
+  context 'passing an explicit host for reverse zone 192.168 (reverse=>"reverse")' do
+    let :params do {
+        :zone       => '192.168',
+        :host       => '@',
+        :data       => 'ns4.jp.example.net.'
+    } end
+    let :pre_condition do [
+        'dns::zone { "192.168": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.@,192.168,NS,ns4.jp.example.net..record').with_content(/^@\s+IN\s+NS\s+ns4.jp.example.net\.$/) }
+  end
+
+  context 'passing an explicit host for reverse zone 128.168.192 (reverse=>true)' do
+    let :params do {
+        :zone       => '128.168.192',
+        :host       => '@',
+        :data       => 'ns4.jp.example.net.'
+    } end
+    let :pre_condition do [
+        'dns::zone { "128.168.192": reverse => true, }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.128.168.192.@,128.168.192,NS,ns4.jp.example.net..record').with_content(/^@\s+IN\s+NS\s+ns4.jp.example.net\.$/) }
+  end
+
+  context 'passing an explicit host for reverse zone 192.168.128 (reverse=>"reverse")' do
+    let :params do {
+        :zone       => '192.168.128',
+        :host       => '@',
+        :data       => 'ns4.jp.example.net.'
+    } end
+    let :pre_condition do [
+        'dns::zone { "192.168.128": reverse => "reverse", }',
+    ] end
+    it { should_not raise_error }
+    it { should contain_concat__fragment('db.192.168.128.@,192.168.128,NS,ns4.jp.example.net..record').with_content(/^@\s+IN\s+NS\s+ns4.jp.example.net\.$/) }
+  end
+
   context 'passing a wrong (numeric top-level domain) zone' do
     let :params do {
         :zone => 'six.022',
@@ -33,7 +111,7 @@ describe 'dns::record::ns', :type => :define do
 
   context 'passing a wrong (numeric) zone' do
     let :params do {
-        :zone => 789,
+        :zone => '789',
         :data => 'badzone.example.com'
     } end
     it { should raise_error(Puppet::Error, /must be a valid domain name/) }

--- a/spec/defines/dns__zone_spec.rb
+++ b/spec/defines/dns__zone_spec.rb
@@ -5,6 +5,16 @@ describe 'dns::zone' do
   let(:title) { 'test.com' }
   let(:facts) {{ :osfamily => 'Debian', :concat_basedir => '/mock_dir' }}
 
+  describe 'passing camelcase name zone than lowercase name zone to $title ' do
+      let(:title)  { 'TeSt.cOm' }
+      it { should raise_error(/must be lowercase/) }
+  end
+
+  describe 'passing uppercase name zone than lowercase name zone to $title ' do
+      let(:title)  { 'TEST.COM' }
+      it { should raise_error(/must be lowercase/) }
+  end
+
   describe 'passing something other than an array to $allow_query ' do
       let(:params) {{ :allow_query => '127.0.0.1' }}
       it { should raise_error(Puppet::Error, /is not an Array/) }
@@ -291,6 +301,101 @@ describe 'dns::zone' do
     end
     it { should contain_concat__fragment('named.conf.local.test.com.include').with_content(/ also-notify \{/) }
     it { should contain_concat__fragment('named.conf.local.test.com.include').with_content(/8\.8\.8\.8;/) }
+  end
+
+  describe 'passing "192.168.notcorrect" to $title with reverse=>"reverse" ' do
+    let(:title)  { '192.168.notcorrect' }
+    let :params do
+      { :reverse => 'reverse' }
+    end
+    it { should raise_error(/Name zone with parameter reverse /) }
+  end
+
+  describe 'passing "168.192.notcorrect" to $title with reverse=>true ' do
+    let(:title)  { '168.192.notcorrect' }
+    let :params do
+      { :reverse => true }
+    end
+    it { should raise_error(/Name zone with parameter reverse /) }
+  end
+
+  describe 'passing "notcorrect.168.192.in-addr.arpa" to $title with reverse=>false ' do
+    let(:title)  { 'notcorrect.168.192.in-addr.arpa' }
+    let :params do
+      { :reverse => false }
+    end
+    it { should raise_error(/Name zone with parameter reverse /) }
+  end
+
+  describe 'passing "192.168" to $title with reverse=>"reverse" and pre_condition dns::zone{ "168.192.in-addr.arpa": reverse => false } (Twin zones)' do
+    let :pre_condition do [
+        'dns::zone { "168.192.in-addr.arpa": reverse => false, }',
+    ] end
+    let(:title)  { '192.168' }
+    let :params do
+      { :reverse => 'reverse' }
+    end
+    it { should raise_error(Puppet::Error, /Duplicate declaration\: Exec\[bump-168\.192\.in-addr\.arpa-serial\] is already declared in file/)}
+  end
+
+  describe 'passing "192.168" to $title with reverse=>"reverse" and pre_condition dns::zone{ "168.192": reverse => true } (Twin zones)' do
+    let :pre_condition do [
+        'dns::zone { "168.192": reverse => true, }',
+    ] end
+    let(:title)  { '192.168' }
+    let :params do
+      { :reverse => 'reverse' }
+    end
+    it { should raise_error(Puppet::Error, /Duplicate declaration\: Exec\[bump-168\.192\.in-addr\.arpa-serial\] is already declared in file/)}
+  end
+
+  describe 'passing "168.192" to $title with reverse=>true and pre_condition dns::zone{ "168.192.in-addr.arpa": reverse => false } (Twin zones)' do
+    let :pre_condition do [
+        'dns::zone { "168.192.in-addr.arpa": reverse => false, }',
+    ] end
+    let(:title)  { '168.192' }
+    let :params do
+      { :reverse => true }
+    end
+    it { should raise_error(Puppet::Error, /Duplicate declaration\: Exec\[bump-168\.192\.in-addr\.arpa-serial\] is already declared in file/)}
+  end
+
+  describe 'passing "168.192" to $title with reverse=>true and pre_condition dns::zone{ "192.168": reverse => "reverse" } (Twin zones)' do
+    let :pre_condition do [
+        'dns::zone { "192.168": reverse => "reverse", }',
+    ] end
+    let(:title)  { '168.192' }
+    let :params do
+      { :reverse => true }
+    end
+    it { should raise_error(Puppet::Error, /Duplicate declaration\: Exec\[bump-168\.192\.in-addr\.arpa-serial\] is already declared in file/)}
+  end
+
+  describe 'passing "168.192.in-addr.arpa" to $title with reverse=>false and pre_condition dns::zone{ "168.192": reverse => true } (Twin zones)' do
+    let :pre_condition do [
+        'dns::zone { "168.192": reverse => true, }',
+    ] end
+    let(:title)  { '168.192.in-addr.arpa' }
+    let :params do
+      { :reverse => false }
+    end
+    it { should raise_error(Puppet::Error, /Duplicate declaration\: Exec\[bump-168\.192\.in-addr\.arpa-serial\] is already declared in file/)}
+  end
+
+  describe 'passing "168.192.in-addr.arpa" to $title with reverse=>false and pre_condition dns::zone{ "192.168": reverse => "reverse" } (Twin zones)' do
+    let :pre_condition do [
+        'dns::zone { "192.168": reverse => "reverse", }',
+    ] end
+    let(:title)  { '168.192.in-addr.arpa' }
+    let :params do
+      { :reverse => false }
+    end
+    it { should raise_error(Puppet::Error, /Duplicate declaration\: Exec\[bump-168\.192\.in-addr\.arpa-serial\] is already declared in file/)}
+  end
+
+  describe 'passing something other than an array to $allow_query ' do
+      let(:params) {{ :allow_query => '127.0.0.1' }}
+      it { should raise_error(Puppet::Error, /is not an Array/) }
   end
 
   context 'passing true to reverse' do

--- a/spec/fixtures/manifests/init.pp
+++ b/spec/fixtures/manifests/init.pp
@@ -7,7 +7,7 @@ node 'testhost.example.com' {
     soa_email   => 'admin.example.com',
     nameservers => [ 'ns1.example.com', ]
   }
-  dns::zone { '1.168.192.IN-ADDR.ARPA':
+  dns::zone { '1.168.192.in-addr.arpa':
     soa         => 'ns1.example.com',
     soa_email   => 'admin.example.com',
     nameservers => [ 'ns1.example.com', ]

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -14,7 +14,7 @@ dns::zone { 'example.com':
   allow_query    => [ '192.168.0.0/16' ],
 }
 
-dns::zone { '56.168.192.IN-ADDR.ARPA':
+dns::zone { '56.168.192.in-addr.arpa':
   soa         => 'ns1.example.com',
   soa_email   => 'admin.example.com',
   nameservers => [ 'ns1' ],


### PR DESCRIPTION
List of changes:
- Disable sensitivity case in defines dns::record::ptr::by_ip and dns::zone;
- Corrected work of defines dns::record::ptr::by_ip and dns::zone;
- Added tests for twin domain zones.
