### PR TITLE
Rework `zone.pp` to create new `dns::zone` resource for `reverse` zones

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -222,6 +222,8 @@ define dns::zone (
   }
 
   if $reverse {
+    # validate that $zone consists of 1 to 3 valid IP octets followed by in-addr.arpa
+    validate_re($zone, '^((25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.){1,3}in-addr.arpa$', 'With reverse != false, zone names must consist of 1 to 3 dot (.) separated numbers in the range 0 - 255.')
     dns::zone { $zone:
       ensure          => $ensure,
       soa             => $soa,

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -112,6 +112,12 @@
 #   of the zone for which the slave will continue to respond to DNS
 #   queries for records in this zone.
 #
+# [*zone_file*]
+#   An internal-use-only parameter used to preserve the original zone
+#   filename during transformations for mixed-case zone names or the
+#   `reverse` parameter.  This parameter should never be specified by
+#   a calling module.
+#
 # [*zone_minimum*]
 #   Despite _minimum_ in the parameter name, this is the maximum time
 #   that a _negative_ for this zone (e.g. a host not found response)
@@ -164,7 +170,10 @@ define dns::zone (
   $slave_masters = undef,
   $zone_notify = undef,
   $also_notify = [],
-  $ensure = present
+  $ensure = present,
+  $zone_file = "${dns::server::params::data_dir}/db.${name}",
+# if you add new parameters here, make sure you also add them to the
+# `if $reverse` blocks below
 ) {
 
   $cfg_dir = $dns::server::params::cfg_dir
@@ -182,21 +191,12 @@ define dns::zone (
     fail("The zone_notify must be ${valid_zone_notify}")
   }
 
-  $zone = $reverse ? {
-    'reverse' => join(reverse(split("arpa.in-addr.${name}", '\.')), '.'),
-    true      => "${name}.in-addr.arpa",
-    default   => $name
-  }
-
   validate_string($zone_type)
   $valid_zone_type_array = ['master', 'slave', 'forward', 'delegation-only']
   if !member($valid_zone_type_array, $zone_type) {
     $valid_zone_type_array_str = join($valid_zone_type_array, ',')
     fail("The zone_type must be one of [${valid_zone_type_array}]")
   }
-
-  $zone_file = "${dns::server::params::data_dir}/db.${name}"
-  $zone_file_stage = "${zone_file}.stage"
 
   validate_array($allow_update)
   # Replace when updates allowed
@@ -206,7 +206,69 @@ define dns::zone (
     $zone_replace = false
   }
 
-  if $ensure == absent {
+  # validate $zone_file is located inside $dns::server::params::data_dir
+  # and begins with `db.`.
+  #
+  # Transform $dns::server::params::data_dir into a regex first :P
+  $data_dir_re = regsubst($dns::server::params::data_dir, '(\W)', '\\\1', 'G')
+  validate_re($zone_file, "^${data_dir_re}/db\\.[^/]*\$", 'zone_file is a private parameter and should not be passed in.')
+
+  $zone_file_stage = "${zone_file}.stage"
+
+  $zone = $reverse ? {
+    'reverse' => join(reverse(split("arpa.in-addr.${name}", '\.')), '.'),
+    true      => "${name}.in-addr.arpa",
+    default   => $name
+  }
+
+  if $reverse {
+    dns::zone { $zone:
+      ensure          => $ensure,
+      soa             => $soa,
+      soa_email       => $soa_email,
+      zone_ttl        => $zone_ttl,
+      zone_refresh    => $zone_refresh,
+      zone_retry      => $zone_retry,
+      zone_expire     => $zone_expire,
+      zone_minimum    => $zone_minimum,
+      nameservers     => $nameservers,
+      reverse         => false, # make sure we don't infinitely recurse!
+      zone_type       => $zone_type,
+      allow_transfer  => $allow_transfer,
+      allow_forwarder => $allow_forwarder,
+      allow_query     => $allow_query,
+      allow_update    => $allow_update,
+      forward_policy  => $forward_policy,
+      slave_masters   => $slave_masters,
+      zone_notify     => $zone_notify,
+      also_notify     => $also_notify,
+      zone_file       => $zone_file,
+    }
+  } elsif $zone != downcase($zone) {
+    $zone_lower = downcase($zone)
+    dns::zone { $zone_lower:
+      ensure          => $ensure,
+      soa             => $soa,
+      soa_email       => $soa_email,
+      zone_ttl        => $zone_ttl,
+      zone_refresh    => $zone_refresh,
+      zone_retry      => $zone_retry,
+      zone_expire     => $zone_expire,
+      zone_minimum    => $zone_minimum,
+      nameservers     => $nameservers,
+      reverse         => $reverse,
+      zone_type       => $zone_type,
+      allow_transfer  => $allow_transfer,
+      allow_forwarder => $allow_forwarder,
+      allow_query     => $allow_query,
+      allow_update    => $allow_update,
+      forward_policy  => $forward_policy,
+      slave_masters   => $slave_masters,
+      zone_notify     => $zone_notify,
+      also_notify     => $also_notify,
+      zone_file       => $zone_file,
+    }
+  } elsif $ensure == absent {
     file { $zone_file:
       ensure => absent,
     }

--- a/spec/defines/dns__zone_spec.rb
+++ b/spec/defines/dns__zone_spec.rb
@@ -298,8 +298,8 @@ describe 'dns::zone' do
     let :params do
       { :reverse => true }
     end
-    it { should contain_concat__fragment('named.conf.local.10.23.45.include').with_content(/zone "10\.23\.45\.in-addr\.arpa"/) }
-    it { should contain_concat__fragment('db.10.23.45.soa').with_content(/\$ORIGIN\s+10\.23\.45\.in-addr\.arpa\./) }
+    it { should contain_concat__fragment('named.conf.local.10.23.45.in-addr.arpa.include').with_content(/zone "10\.23\.45\.in-addr\.arpa"/) }
+    it { should contain_concat__fragment('db.10.23.45.in-addr.arpa.soa').with_content(/\$ORIGIN\s+10\.23\.45\.in-addr\.arpa\./) }
   end
 
   context 'passing reverse to reverse' do
@@ -307,8 +307,8 @@ describe 'dns::zone' do
     let :params do
       { :reverse => 'reverse' }
     end
-    it { should contain_concat__fragment('named.conf.local.10.23.45.include').with_content(/zone "45\.23\.10\.in-addr\.arpa"/) }
-    it { should contain_concat__fragment('db.10.23.45.soa').with_content(/\$ORIGIN\s+45\.23\.10\.in-addr\.arpa\./) }
+    it { should contain_concat__fragment('named.conf.local.45.23.10.in-addr.arpa.include').with_content(/zone "45\.23\.10\.in-addr\.arpa"/) }
+    it { should contain_concat__fragment('db.45.23.10.in-addr.arpa.soa').with_content(/\$ORIGIN\s+45\.23\.10\.in-addr\.arpa\./) }
   end
 
   describe 'passing something other than an array to $allow_update ' do
@@ -345,5 +345,27 @@ describe 'dns::zone' do
           with_content(/2001:db8::\/32/)
     }
   end
+
+  describe 'passing a zone_file with an invalid directory' do
+    let(:params) {{ :zone_file => '/tmp/foo' }}
+    it { should raise_error(Puppet::Error, /is a private parameter/) }
+  end
+
+  describe 'passing a zone_file with an invalid filename' do
+    let(:params) {{ :zone_file => '/etc/bind/zones/foo' }}
+    it { should raise_error(Puppet::Error, /is a private parameter/) }
+  end
+
+  describe 'passing a zone_file with a subdirectory of the data directory' do
+    let(:params) {{ :zone_file => '/etc/bind/zones/db.sneaky/foo' }}
+    it { should raise_error(Puppet::Error, /is a private parameter/) }
+  end
+
+  describe 'passing a zone_file with a valid filename' do
+    let(:params) {{ :zone_file => '/etc/bind/zones/db.foo' }}
+    it { should_not raise_error }
+    it { should contain_concat('/etc/bind/zones/db.foo.stage') }
+  end
+
 end
 

--- a/spec/defines/dns__zone_spec.rb
+++ b/spec/defines/dns__zone_spec.rb
@@ -302,6 +302,30 @@ describe 'dns::zone' do
     it { should contain_concat__fragment('db.10.23.45.in-addr.arpa.soa').with_content(/\$ORIGIN\s+10\.23\.45\.in-addr\.arpa\./) }
   end
 
+  context 'passing true to reverse with an alphanumeric zone name' do
+    let(:title) { 'invalid.zone' }
+    let :params do
+      { :reverse => true }
+    end
+    it { should raise_error(Puppet::Error, /zone names must consist of/) }
+  end
+
+  context 'passing true to reverse with an invalid octet' do
+    let(:title) { '10.23.456' }
+    let :params do
+      { :reverse => true }
+    end
+    it { should raise_error(Puppet::Error, /zone names must consist of/) }
+  end
+
+  context 'passing true to reverse with too many octets' do
+    let(:title) { '10.23.45.67' }
+    let :params do
+      { :reverse => true }
+    end
+    it { should raise_error(Puppet::Error, /zone names must consist of/) }
+  end
+
   context 'passing reverse to reverse' do
     let(:title) { '10.23.45' }
     let :params do
@@ -309,6 +333,30 @@ describe 'dns::zone' do
     end
     it { should contain_concat__fragment('named.conf.local.45.23.10.in-addr.arpa.include').with_content(/zone "45\.23\.10\.in-addr\.arpa"/) }
     it { should contain_concat__fragment('db.45.23.10.in-addr.arpa.soa').with_content(/\$ORIGIN\s+45\.23\.10\.in-addr\.arpa\./) }
+  end
+
+  context 'passing reverse to reverse with an alphanumeric zone name' do
+    let(:title) { 'invalid.zone' }
+    let :params do
+      { :reverse => 'reverse' }
+    end
+    it { should raise_error(Puppet::Error, /zone names must consist of/) }
+  end
+
+  context 'passing reverse to reverse with an invalid octet' do
+    let(:title) { '10.23.456' }
+    let :params do
+      { :reverse => 'reverse' }
+    end
+    it { should raise_error(Puppet::Error, /zone names must consist of/) }
+  end
+
+  context 'passing reverse to reverse with too many octets' do
+    let(:title) { '10.23.45.67' }
+    let :params do
+      { :reverse => 'reverse' }
+    end
+    it { should raise_error(Puppet::Error, /zone names must consist of/) }
   end
 
   describe 'passing something other than an array to $allow_update ' do


### PR DESCRIPTION
In order to simplify and standardize the creation of dns zones, and to make it easier to verify the existence of dns zones in other resources, when the `reverse` parameter is set to a non-`false` value, a new `dns::zone` resource is created with the proper zone name.

In order to not break existing installations, the new resource makes use of a new `zone_file` parameter to pass in the zone filenam based on the original non-reversed zone name.  The `zone_file` parameter is validated to ensure it's in the dns data directory and begins with `db.`.

For example, `dns::zone { '10.23.45': reverse => reverse }` will result in a new `dns::zone` resource looking something like this:

```
dns::zone { '45.23.10.in-addr.arpa':
    reverse => false,
    zone_file => '.../db.10.23.45'
}
```

The `...` in the `zone_file` parameter will be replaced by the actual path to the zone file, parameterized in `$dns::server::params::data_dir`.

In addition, any `dns::zone` resource that contains uppercase letters in the zone name will have a new `dns::zone` resource created in which the zone name is all lowercase.  For example, `dns::zone { 'Example.COM': }` would result in a new `dns::zone` resource looking something like this:

```
dns::zone { 'example.com':
    zone_file => '.../db.Example.COM'
}
```

Finally, added `spec` tests against the `zone_file` parameter validation.
