### PR TITLE
Make data_dir configurable in defined resource types.

### DIFF
--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -10,10 +10,9 @@ define dns::record (
   $dns_class = 'IN',
   $ttl = '',
   $preference = false,
-  $order = 9
+  $order = 9,
+  $data_dir = $::dns::server::params::data_dir,
 ) {
-
-  $data_dir = $dns::server::params::data_dir
 
   $zone_file_stage = "${data_dir}/db.${zone}.stage"
 

--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -78,7 +78,6 @@
 #   Debian and on RedHat 6 and above.
 #   Note: If *dnssec_enable* is set to false, this option is ignored.
 #
-#
 # [*dnssec_enable*]
 #   Controls whether to enable/disable DNS-SEC support. Boolean.
 #   Default is false on RedHat 5 (for the same reasons as
@@ -98,6 +97,10 @@
 #   The source IP address from which to respond to transfer requests.
 #   Default: undef, meaning the primary IP address of the DNS server,
 #   as determined by BIND.
+#
+# [*data_dir*]
+#   Bind data directory.
+#   Default: /etc/bind/zones
 #
 # === Examples
 #
@@ -122,15 +125,15 @@ define dns::server::options (
   $statistic_channel_allow = undef,
   $zone_notify = undef,
   $also_notify = [],
-  $dnssec_validation = $dns::server::params::default_dnssec_validation,
-  $dnssec_enable = $dns::server::params::default_dnssec_enable,
+  $dnssec_validation = $::dns::server::params::default_dnssec_validation,
+  $dnssec_enable = $::dns::server::params::default_dnssec_enable,
   $no_empty_zones = false,
   $notify_source = undef,
   $transfer_source = undef,
+  $data_dir = $::dns::server::params::data_dir,
 ) {
   $valid_check_names = ['fail', 'warn', 'ignore']
   $cfg_dir = $::dns::server::params::cfg_dir
-  $data_dir = $::dns::server::params::data_dir
 
   if ! defined(Class['::dns::server']) {
     fail('You must include the ::dns::server base class before using any dns options defined resources')

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -71,6 +71,10 @@
 #   reloads the zone file.  See the *allow_forwarder* parameter for how
 #   to include the optional port numbers.
 #
+# [*data_dir*]
+#   Bind data directory.
+#   Default: /etc/bind/zones
+#
 # [*forward_policy*]
 #   Either `first` or `only`.  If the *allow_forwarder* array is not
 #   empty, this setting defines how query forwarding is handled.  With a
@@ -168,7 +172,8 @@ define dns::zone (
   $slave_masters = undef,
   $zone_notify = undef,
   $also_notify = [],
-  $ensure = present
+  $ensure = present,
+  $data_dir = $::dns::server::params::data_dir,
 ) {
 
   $cfg_dir = $dns::server::params::cfg_dir
@@ -199,7 +204,7 @@ define dns::zone (
     fail("The zone_type must be one of [${valid_zone_type_array}]")
   }
 
-  $zone_file = "${dns::server::params::data_dir}/db.${name}"
+  $zone_file = "${data_dir}/db.${name}"
   $zone_file_stage = "${zone_file}.stage"
 
   validate_array($allow_update)


### PR DESCRIPTION
The module default settings for data_dir is '/etc/bind/zones'. In Ubuntu
this is not possible without apparmor config adjustments, because by
default apparmor denies changes in this directory.

Therefore it should be possible to change the data_dir in this module.