### PR TITLE
Add support for stub zones

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -100,7 +100,7 @@
 #   Optional set or time bases auto generated serial numver of zone file
 #
 # [*slave_masters*]
-#   If *zone_type* is set to `slave`, this holds an array or string
+#   If *zone_type* is set to `slave` or `stub`, this holds an array or string
 #   containing the IP addresses of the DNS servers from which this slave
 #   transfers the zone.  If a string, the IP addresses must be separated
 #   by semicolons (`;`).
@@ -148,8 +148,9 @@
 #
 # [*zone_type*]
 #   The type of DNS zone being described.  Can be one of `master`, `slave`
-#   (requires *slave_masters* to be set), `delegation-only`, or `forward`
-#   (requires both *allow_forwarder* and *forward_policy* to be set).
+#   (requires *slave_masters* to be set), `stub` (requires *slave_masters*
+#   to be set), `delegation-only`, or `forward` (requires both
+#   *allow_forwarder* and *forward_policy* to be set).
 #   Defaults to `master`.
 #
 define dns::zone (
@@ -198,7 +199,7 @@ define dns::zone (
   }
 
   validate_string($zone_type)
-  $valid_zone_type_array = ['master', 'slave', 'forward', 'delegation-only']
+  $valid_zone_type_array = ['master', 'slave', 'stub', 'forward', 'delegation-only']
   if !member($valid_zone_type_array, $zone_type) {
     $valid_zone_type_array_str = join($valid_zone_type_array, ',')
     fail("The zone_type must be one of [${valid_zone_type_array}]")

--- a/spec/defines/dns__zone_spec.rb
+++ b/spec/defines/dns__zone_spec.rb
@@ -190,6 +190,51 @@ describe 'dns::zone' do
       end
   end
 
+  context 'with a stub zone' do
+      let :params do
+          { :slave_masters => ['123.123.123.123'],
+            :zone_type => 'stub'
+          }
+      end
+      it 'should have a type stub entry' do
+          should contain_concat__fragment('named.conf.local.test.com.include').
+                     with_content(/type stub/)
+      end
+      it 'should have file entry' do
+          should contain_concat__fragment('named.conf.local.test.com.include').
+                         with_content(/file/)
+      end
+      it 'should have masters entry' do
+          should contain_concat__fragment('named.conf.local.test.com.include').
+                         with_content(/masters.*123.123.123.123 *;/)
+      end
+      it 'should not have allow_tranfer entry' do
+          should_not contain_concat__fragment('named.conf.local.test.com.include').
+                     with_content(/allow-transfer/)
+      end
+      it 'should not have any forward information' do
+          should_not contain_concat__fragment('named.conf.local.test.com.include').
+                         with_content(/forward/)
+      end
+      it 'should have an "absent" zone file concat' do
+          should contain_concat('/etc/bind/zones/db.test.com.stage').with({
+              :ensure => "absent"
+          })
+      end
+  end
+
+  context 'with a stub zone with multiple masters' do
+      let :params do
+          { :slave_masters => ['123.123.123.123', '234.234.234.234'],
+            :zone_type => 'stub'
+          }
+      end
+      it 'should have masters entry with all masters joined by ;' do
+          should contain_concat__fragment('named.conf.local.test.com.include').
+                         with_content(/masters.*123.123.123.123 *;[ \n]*234.234.234.234 *;/)
+      end
+  end
+
   context 'with a master zone' do
       let :params do
           { :allow_transfer => ['8.8.8.8','8.8.4.4'],

--- a/templates/zone.erb
+++ b/templates/zone.erb
@@ -13,7 +13,7 @@ zone "<%= @zone %>" {
 <% if (@zone_type != 'forward') && (@zone_type != 'delegation-only')-%>
     file "<%= @zone_file %>";
 <% end -%>
-<% if @zone_type == 'slave' -%>
+<% if @zone_type == 'slave' or @zone_type == 'stub' -%>
 <%- if @slave_masters.is_a?(Array) -%>
     masters { <%= @slave_masters.join(";") %>;};
 <%- else -%>


### PR DESCRIPTION
This branch/PR adds support for the _stub_ [zone type](http://ftp.isc.org/isc/bind9/cur/9.9/doc/arm/Bv9ARM.ch06.html#zone_statement).