### PR TITLE
fixing path issue which prevents working when path is not /etc/bind

### DIFF
--- a/manifests/tsig.pp
+++ b/manifests/tsig.pp
@@ -25,11 +25,12 @@ define dns::tsig (
   $ensure    = present
 ) {
 
+  $cfg_dir   = $dns::server::params::cfg_dir # Used in a template
   validate_string($name)
 
   concat::fragment { "named.conf.local.tsig.${name}.include":
     ensure  => $ensure,
-    target  => '/etc/bind/named.conf.local',
+    target  => "${cfg_dir}/named.conf.local",
     order   => 4,
     content => template("${module_name}/tsig.erb"),
   }


### PR DESCRIPTION
Currently the config_dir part of this was set to /etc/bind.   Changed to module variable config_dir for proper execution.