### PR TITLE
Add global `forward` policy to the `options` block

### DIFF
--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -47,6 +47,10 @@
 #   dnssec_validation above), and true on Debian and on RedHat 6
 #   and above.
 #
+# [*forward_policy*]
+#   The forwarding policy to use.  Must be `first` or `only`.
+#   If not defined, the `named` default of `first` will be used.
+#
 # [*forwarders*]
 #   Array of forwarders IP addresses. Default: empty
 #
@@ -128,6 +132,7 @@ define dns::server::options (
   $data_dir = $::dns::server::params::data_dir,
   $dnssec_validation = $::dns::server::params::default_dnssec_validation,
   $dnssec_enable = $::dns::server::params::default_dnssec_enable,
+  $forward_policy = undef,
   $forwarders = [],
   $listen_on = [],
   $listen_on_ipv6 = [],
@@ -144,12 +149,17 @@ define dns::server::options (
   $zone_notify = undef,
 ) {
   $valid_check_names = ['fail', 'warn', 'ignore']
+  $valid_forward_policy = ['first', 'only']
   $cfg_dir = $::dns::server::params::cfg_dir
 
   if ! defined(Class['::dns::server']) {
     fail('You must include the ::dns::server base class before using any dns options defined resources')
   }
 
+  validate_string($forward_policy)
+  if $forward_policy != undef and !member($valid_forward_policy, $forward_policy) {
+    fail("The forward_policy must be ${valid_forward_policy}")
+  }
   validate_array($forwarders)
   validate_array($transfers)
   validate_array($listen_on)

--- a/spec/defines/dns__server__options_spec.rb
+++ b/spec/defines/dns__server__options_spec.rb
@@ -385,5 +385,37 @@ describe 'dns::server::options', :type => :define do
     it { should raise_error(Puppet::Error, /is not an absolute/) }
   end
 
+  context 'not passing forward_policy' do
+    it { should contain_file('/etc/bind/named.conf.options').without_content(/ forward /) }
+  end
+
+  context 'passing forward_policy as `only`' do
+    let :params do
+      { :forward_policy => 'only' }
+    end
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/ forward  *only *;/) }
+  end
+
+  context 'passing forward_policy as `first`' do
+    let :params do
+      { :forward_policy => 'first' }
+    end
+    it { should contain_file('/etc/bind/named.conf.options').with_content(/ forward  *first *;/) }
+  end
+
+  context 'passing forward_policy as an invalid string' do
+    let :params do
+      { :forward_policy => 'snozberry' }
+    end
+    it { should raise_error(Puppet::Error, /The forward_policy must be/) }
+  end
+
+  context 'passing forward_policy as an invalid type' do
+    let :params do
+      { :forward_policy => ['first'] }
+    end
+    it { should raise_error(Puppet::Error, /is not a string/) }
+  end
+
 end
 

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -22,6 +22,11 @@ options {
     };
 
 <% end -%>
+
+<% if @forward_policy then -%>
+    forward <%= @forward_policy %>;
+<% end -%>
+
 <% if @transfers.size != 0 then -%>
     allow-transfer {
     <%- @transfers.each do |transfer| -%>


### PR DESCRIPTION
Controlled by `dns::server::options` parameter `forward_policy`

Add `forward_policy` to spec tests