### PR TITLE
Fix PuppetLint log_format configuration to use `%{line}`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ rescue LoadError
 end
 
 PuppetLint.configuration.send("disable_80chars")
-PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+PuppetLint.configuration.log_format = "%{path}:%{line}:%{check}:%{KIND}:%{message}"
 
 # Forsake support for Puppet 2.6.2 for the benefit of cleaner code.
 # http://puppet-lint.com/checks/class_parameter_defaults/


### PR DESCRIPTION
... instead of `%{linenumber}`.  puppet-lint 1.0.0 changed `%{linenumber}`
to `%{line}` for the log_format option.