### PR TITLE
Fix breaking tests on old puppet and ruby

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,8 @@
 fixtures:
   forge_modules:
     stdlib: "puppetlabs/stdlib"
-    concat: "puppetlabs/concat"
+    concat:
+      repo: "puppetlabs/concat"
+      ref: "2.2.0"
   symlinks:
     dns: "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -23,5 +23,5 @@ group :test do
   gem "rspec-puppet", "~> 2.1"
 
   gem "puppet-syntax"
-  gem "puppetlabs_spec_helper"
+  gem "puppetlabs_spec_helper", "< 2.1.1"
 end

--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">=1.0.0 <3.0.0"
+      "version_requirement": ">=1.0.0 <2.2.1"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Restrict puppetlabs-concat version to < 2.2.1

The puppetlabs-concat module version `2.2.1` (just released) introduces a breaking change for Puppet < `3.2.0`: it includes the use of `Puppet::Parameter::Boolean` for type checking, but those parameter types were not introduced until `3.2.0`.

----

Restrict puppetlabs_spec_helper gem version to < 2.1.1

puppetlabs_spec_helper gem version `2.1.1` introduces a dependency on the `parallel` gem, which requires Ruby 2.0.  This breaks all testing on older Ruby versions.
