### PR TITLE
Add dns::server::view

### DIFF
--- a/files/named.conf.default-zones
+++ b/files/named.conf.default-zones
@@ -1,0 +1,30 @@
+// File managed with puppet
+// prime the server with knowledge of the root servers
+zone "." {
+	type hint;
+	file "/etc/bind/db.root";
+};
+
+// be authoritative for the localhost forward and reverse zones, and for
+// broadcast zones as per RFC 1912
+
+zone "localhost" {
+	type master;
+	file "/etc/bind/db.local";
+};
+
+zone "127.in-addr.arpa" {
+	type master;
+	file "/etc/bind/db.127";
+};
+
+zone "0.in-addr.arpa" {
+	type master;
+	file "/etc/bind/db.0";
+};
+
+zone "255.in-addr.arpa" {
+	type master;
+	file "/etc/bind/db.255";
+};
+

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -11,16 +11,19 @@ class dns::server (
   $data_dir = $dns::server::params::data_dir,
   $owner    = $dns::server::params::owner,
   $group    = $dns::server::params::group,
+
+  $enable_default_zones = true,
 ) inherits dns::server::params {
   class { 'dns::server::install':
     necessary_packages => $necessary_packages,
     ensure_packages    => $ensure_packages,
   } -> class { 'dns::server::config':
-    cfg_dir  => $cfg_dir,
-    cfg_file => $cfg_file,
-    data_dir => $data_dir,
-    owner    => $owner,
-    group    => $group,
+    cfg_dir              => $cfg_dir,
+    cfg_file             => $cfg_file,
+    data_dir             => $data_dir,
+    owner                => $owner,
+    group                => $group,
+    enable_default_zones => $enable_default_zones,
   } ~> class { 'dns::server::service':
     service => $service,
   }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -57,7 +57,7 @@ class dns::server::config (
   }
 
   # Configure default zones with a concat so we could add more zones in it
-  concat {$rfc1912_zones_cfg:
+  concat {$dns::server::params::rfc1912_zones_cfg:
     owner          => $owner,
     group          => $group,
     mode           => '0644',
@@ -66,7 +66,7 @@ class dns::server::config (
   }
 
   concat::fragment {'default-zones.header':
-    target => $rfc1912_zones_cfg,
+    target => $dns::server::params::rfc1912_zones_cfg,
     order  => '00',
     source => "puppet:///modules/${module_name}/named.conf.default-zones",
   }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,11 +1,12 @@
 # == Class dns::server
 #
 class dns::server::config (
-  $cfg_dir  = $dns::server::params::cfg_dir,
-  $cfg_file = $dns::server::params::cfg_file,
-  $data_dir = $dns::server::params::data_dir,
-  $owner    = $dns::server::params::owner,
-  $group    = $dns::server::params::group,
+  $cfg_dir              = $dns::server::params::cfg_dir,
+  $cfg_file             = $dns::server::params::cfg_file,
+  $data_dir             = $dns::server::params::data_dir,
+  $owner                = $dns::server::params::owner,
+  $group                = $dns::server::params::group,
+  $enable_default_zones = true,
 ) inherits dns::server::params {
 
   file { $cfg_dir:

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -56,6 +56,21 @@ class dns::server::config (
     content => "// File managed by Puppet.\n"
   }
 
+  # Configure default zones with a concat so we could add more zones in it
+  concat {$rfc1912_zones_cfg:
+    owner          => $owner,
+    group          => $group,
+    mode           => '0644',
+    ensure_newline => true,
+    notify         => Class['dns::server::service'],
+  }
+
+  concat::fragment {'default-zones.header':
+    target => $rfc1912_zones_cfg,
+    order  => '00',
+    source => "puppet:///modules/${module_name}/named.conf.default-zones",
+  }
+
   include dns::server::default
 
 }

--- a/manifests/server/view.pp
+++ b/manifests/server/view.pp
@@ -102,7 +102,7 @@ define dns::server::view (
     concat::fragment {"named.conf.local.view.${name}.include":
       target  => "${dns::server::params::cfg_dir}/named.conf.local",
       order   => $order,
-      content => "include \"${dns::server::params::cfg_dir}/view-${name}.conf\";",
+      content => "include \"${dns::server::params::cfg_dir}/view-${name}.conf\";\n",
       require => Concat["${dns::server::params::cfg_dir}/view-${name}.conf"],
     }
 

--- a/manifests/server/view.pp
+++ b/manifests/server/view.pp
@@ -44,17 +44,35 @@
 #   Defaults to empty (no zone is added).
 #
 define dns::server::view (
-  Enum['present', 'absent'] $ensure                 = 'present',
-  Boolean $enable_default_zones                     = true,
-  Array[String] $match_clients                      = [],
-  Array[String] $match_destinations                 = [],
-  Optional[Enum['yes', 'no']] $match_recursive_only = undef,
-  Hash $options                                     = {},
-  String $order                                     = '50',
-  String $viewname                                  = $name,
-  Hash $zones                                       = {},
+  $ensure               = 'present',
+  $enable_default_zones = true,
+  $match_clients        = [],
+  $match_destinations   = [],
+  $match_recursive_only = undef,
+  $options              = {},
+  $order                = '50',
+  $viewname             = $name,
+  $zones                = {},
 ) {
   include ::dns::server::params
+
+  $valid_ensure = ['present', 'absent']
+  $valid_yes_no = ['yes', 'no']
+  if !member($valid_ensure, $ensure) {
+    fail("ensure parameter must be ${valid_ensure}")
+  }
+  validate_bool($enable_default_zones)
+  validate_array($match_clients)
+  validate_array($match_destinations)
+  if $match_recursive_only {
+    if !member($valid_yes_no, $match_recursive_only) {
+      fail("match_recursive_only parameter must be ${valid_yes_no}")
+    }
+  }
+  validate_hash($options)
+  validate_string($order)
+  validate_string($viewname)
+  validate_hash($zones)
 
   $rfc1912_zones_cfg = $dns::server::params::rfc1912_zones_cfg
 
@@ -89,11 +107,6 @@ define dns::server::view (
     }
 
     # Create zone config
-    $zones.each |$zone, $opts| {
-      $fopts = merge({ view =>  $name }, $opts)
-      dns::zone {$zone:
-        * => $fopts,
-      }
-    }
+    create_resources(dns::zone, $zones, { view => $name })
   }
 }

--- a/manifests/server/view.pp
+++ b/manifests/server/view.pp
@@ -1,0 +1,99 @@
+# == Define dns::server::view
+#
+# `dns::server::view` defines a DNS view.
+#
+# Zones to the view could be added by using the `zones` parameter of
+# `dns::server::view` or by declaring `dns::zone` resources with its `view`
+# parameter set to this resource name.
+#
+# === Parameters
+#
+# [*ensure*]
+#   If the view should be `present` or `absent. Defaults to `present`.
+#
+# [*enable_default_zones*]
+#   Boolean indicating if the default zones (`named.conf.default-zones`) should
+#   be included in this view or not. Defaults to `true`.
+#
+# [*match_clients*]
+#   Array (of strings) with the `match-clients` for the zone. Defaults to empty.
+#
+# [*match_destinations*]
+#   Array (of strings) with the `match-destinations` for the view. Defaults to empty.
+#
+# [*match_recursive_only*]
+#   Value for the `match-recursive-only` option of the view. Defaults to undef
+#   (the option is not configured). Valid values are `yes` and `no`.
+#
+# [*options* ]
+#   Hash with additional options that should be configured in the view.
+#   Defaults to empty (no additional option is added). It should be a hash where
+#   every value should be a string or an array.
+#
+# [*order*]
+#   Order of different views could be important (for example, if `match_clients`
+#   of a view is a superset of the `match_clients` of another). This parameter
+#   could be used to force a different order of the alphatical one.
+#   Defaults to `50`.
+#
+# [*viewname*]
+#   Name of the view. Defaults to `$name`.
+#
+# [*zones*]
+#   Hash of zones resources that should be included in this view.
+#   Defaults to empty (no zone is added).
+#
+define dns::server::view (
+  Enum['present', 'absent'] $ensure                 = 'present',
+  Boolean $enable_default_zones                     = true,
+  Array[String] $match_clients                      = [],
+  Array[String] $match_destinations                 = [],
+  Optional[Enum['yes', 'no']] $match_recursive_only = undef,
+  Hash $options                                     = {},
+  String $order                                     = '50',
+  String $viewname                                  = $name,
+  Hash $zones                                       = {},
+) {
+  include ::dns::server::params
+
+  $rfc1912_zones_cfg = $dns::server::params::rfc1912_zones_cfg
+
+  concat { "${dns::server::params::cfg_dir}/view-${name}.conf":
+    ensure         => $ensure,
+    owner          => $dns::server::params::owner,
+    group          => $dns::server::params::group,
+    mode           => '0644',
+    ensure_newline => true,
+    notify         => Class['dns::server::service'],
+  }
+
+  if $ensure == 'present' {
+    concat::fragment {"view-${name}.header":
+      target  => "${dns::server::params::cfg_dir}/view-${name}.conf",
+      order   =>  '00',
+      content => template("${module_name}/view.erb"),
+    }
+
+    concat::fragment {"view-${name}.tail":
+      target  => "${dns::server::params::cfg_dir}/view-${name}.conf",
+      order   => '99',
+      content => '}; ',
+    }
+
+    # Include view configuration in main config
+    concat::fragment {"named.conf.local.view.${name}.include":
+      target  => "${dns::server::params::cfg_dir}/named.conf.local",
+      order   => $order,
+      content => "include \"${dns::server::params::cfg_dir}/view-${name}.conf\";",
+      require => Concat["${dns::server::params::cfg_dir}/view-${name}.conf"],
+    }
+
+    # Create zone config
+    $zones.each |$zone, $opts| {
+      $fopts = merge({ view =>  $name }, $opts)
+      dns::zone {$zone:
+        * => $fopts,
+      }
+    }
+  }
+}

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -2,6 +2,8 @@
 //
 
 include "<%= @cfg_dir %>/named.conf.options";
+<%- if @enable_default_zones -%>
 include "<%= @rfc1912_zones_cfg %>";
+<%- end -%>
 include "<%= @rndc_key_file %>";
 include "<%= @cfg_dir %>/named.conf.local";

--- a/templates/view.erb
+++ b/templates/view.erb
@@ -1,0 +1,31 @@
+// File managed by puppet
+
+view <%= @viewname %> {
+<%- if !@match_clients.empty? -%>
+  match-clients {
+    <%= @match_clients.join(";\n    ") %>;
+  };
+<%- end %>
+<%- if !@match_destinations.empty? -%>
+  match-destinations {
+    <%= @match_destinations.join(";\n    ") %>;
+  };
+<%- end %>
+<%- if @match_recursive_only -%>
+  match-recursive-only <%= @match_recursive_only %>;
+<%- end -%>
+<%- if !@options.empty? -%>
+  <%- @options.each do |k, v| -%>
+    <%- if v.respond_to?('join') -%>
+  <%= k %> {
+    <%= v.join(";\n    ")%>;
+  };
+    <%- else -%>
+  <%= k %> <%= v %>;
+    <%- end -%>
+  <%- end -%>
+<%- end -%>
+
+<%- if @enable_default_zones -%>
+  include "<%= @rfc1912_zones_cfg %>";
+<%- end -%>


### PR DESCRIPTION
Add `dns::server::view` to configure dns views.
In order to handle this, I have also modified a little the zone implementation to be able to use a file different than _named.conf.local_ to include the zone configurations.
It also adds a `enable_default_zones` to `dns::server` so the inclussion of the `named.conf.default-zones` file could be ommited when views are used (in this case all zones must be defined inside a view, so that file could not be globally included).