### PR TITLE
Find a version of rspec-puppet that works with older puppets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :test do
   # Pin for 1.8.7 compatibility for now
   gem "rspec", '< 3.2.0'
   gem "rspec-core", "3.1.7"
-  gem "rspec-puppet", "~> 2.1"
+  gem "rspec-puppet", "< 2.6.0"
 
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper", "< 2.1.1"


### PR DESCRIPTION
The `rspec-puppet` gem update to version `2.6.0` broke things for Puppet 3.0 - 3.5.  Until this gets fixed (I've got a PR into the `rspec-puppet` github repo for the fix), this change will limit `rspec-puppet` to earlier than `2.6.0`.