### PR TITLE
Use zone for PTR record with host of `@`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :test do
   # Pin for 1.8.7 compatibility for now
   gem "rspec", '< 3.2.0'
   gem "rspec-core", "3.1.7"
-  gem "rspec-puppet", "~> 2.1"
+  gem "rspec-puppet", "< 2.6.0"
 
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper", "< 2.1.1"

--- a/manifests/record/ptr/by_ip.pp
+++ b/manifests/record/ptr/by_ip.pp
@@ -14,6 +14,8 @@
 # domain, it will be appended to the value of `$host` in the `PTR`
 # record; if `$zone` is undefined or empty, then `$host`
 # must include the domain name (but must *not* include any trailing `.`).
+# If `$host` is `@` and `$zone` is non-empty, `$zone` will be used by
+# itself in the `PTR` record.
 #
 # * `$ttl`
 # The TTL of the records to be created.  Defaults to undefined.
@@ -108,7 +110,11 @@ define dns::record::ptr::by_ip (
   }
 
   if $zone != undef and $zone != '' {
-    $fqdn = "${host}.${zone}"
+    if $host == '@' {
+      $fqdn = $zone
+    } else {
+      $fqdn = "${host}.${zone}"
+    }
   } else {
     $fqdn = $host
   }

--- a/spec/defines/dns__record__ptr__by_ip_spec.rb
+++ b/spec/defines/dns__record__ptr__by_ip_spec.rb
@@ -42,5 +42,43 @@ describe 'dns::record::ptr::by_ip', :type => :define do
     }) }
   end
 
+  context 'passing a host of `@` and a valid zone' do
+    let :params do {
+        :host      => '@',
+        :zone      => 'example.com',
+    } end
+    it { should_not raise_error }
+    it { should contain_dns__record__ptr('15.2.0.192.IN-ADDR.ARPA').with({
+      'host' => '15',
+      'zone' => '2.0.192.IN-ADDR.ARPA',
+      'data' => 'example.com',
+    }) }
+  end
+
+  context 'passing a host of `@` and an empty zone' do
+    let :params do {
+        :host      => '@',
+        :zone      => '',
+    } end
+    it { should_not raise_error }
+    it { should contain_dns__record__ptr('15.2.0.192.IN-ADDR.ARPA').with({
+      'host' => '15',
+      'zone' => '2.0.192.IN-ADDR.ARPA',
+      'data' => '@',
+    }) }
+  end
+
+  context 'passing a host of `@` but not passing a zone' do
+    let :params do {
+        :host      => '@',
+    } end
+    it { should_not raise_error }
+    it { should contain_dns__record__ptr('15.2.0.192.IN-ADDR.ARPA').with({
+      'host' => '15',
+      'zone' => '2.0.192.IN-ADDR.ARPA',
+      'data' => '@',
+    }) }
+  end
+
 end
 


### PR DESCRIPTION
In DNS zone files, a host of `@` means the value of `$ORIGIN`, which, for zones configured by this module, means the `$zone` parameter.  This change makes the `dns::record::ptr::by_ip` type catch the `@` name and use the zone if possible.

_Note_ - this is based off of the `jearls_find_rspec_puppet_version_that_works` branch, to ensure the `spec` tests work.

Fixes #226