### PR TITLE
Fix concat::fragment usage.

### DIFF
--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -46,7 +46,6 @@ define dns::key {
   }
 
   Concat::Fragment {
-    ensure  => present,
     target  => "${cfg_dir}/bind.keys.d/${name}.key",
     require => [
       Exec["get-secret-from-${name}"],

--- a/manifests/tsig.pp
+++ b/manifests/tsig.pp
@@ -28,11 +28,12 @@ define dns::tsig (
   $cfg_dir   = $dns::server::params::cfg_dir # Used in a template
   validate_string($name)
 
-  concat::fragment { "named.conf.local.tsig.${name}.include":
-    ensure  => $ensure,
-    target  => "${cfg_dir}/named.conf.local",
-    order   => 4,
-    content => template("${module_name}/tsig.erb"),
+  if $ensure == 'present' {
+    concat::fragment { "named.conf.local.tsig.${name}.include":
+      target  => "${cfg_dir}/named.conf.local",
+      order   => 4,
+      content => template("${module_name}/tsig.erb"),
+    }
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">=1.0.0 <2.2.1"
+      "version_requirement": ">=2.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/defines/dns__key_spec.rb
+++ b/spec/defines/dns__key_spec.rb
@@ -18,7 +18,6 @@ describe 'dns::key' do
     it { should contain_file('/etc/bind/bind.keys.d/rspec-key.secret').with_require('Exec[get-secret-from-rspec-key]') }
     it { should contain_concat('/etc/bind/bind.keys.d/rspec-key.key') }
     ['rspec-key.key-header', 'rspec-key.key-secret', 'rspec-key.key-footer'].each do |fragment|
-      it { should contain_concat__fragment(fragment).with_ensure('present') }
       it { should contain_concat__fragment(fragment).with_target('/etc/bind/bind.keys.d/rspec-key.key') }
       it { should contain_concat__fragment(fragment).with_require(['Exec[get-secret-from-rspec-key]', 'File[/etc/bind/bind.keys.d/rspec-key.secret]']) }
     end
@@ -39,7 +38,6 @@ describe 'dns::key' do
     it { should contain_file('/etc/named/bind.keys.d/rspec-key.secret').with_require('Exec[get-secret-from-rspec-key]') }
     it { should contain_concat('/etc/named/bind.keys.d/rspec-key.key') }
     ['rspec-key.key-header', 'rspec-key.key-secret', 'rspec-key.key-footer'].each do |fragment|
-        it { should contain_concat__fragment(fragment).with_ensure('present') }
         it { should contain_concat__fragment(fragment).with_target('/etc/named/bind.keys.d/rspec-key.key') }
         it { should contain_concat__fragment(fragment).with_require(['Exec[get-secret-from-rspec-key]', 'File[/etc/named/bind.keys.d/rspec-key.secret]']) }
     end


### PR DESCRIPTION
Last versions of concat module have removed the ensure parameter for
concat::fragment (deprecated since v2.0.0).