### PR TITLE
params.pp: exclude dnssec-tools from $necessary_packages for debian >= 8

### DIFF
--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -18,13 +18,10 @@ class dns::server::params {
       $default_template   = 'default.debian.erb'
       $default_dnssec_enable     = true
       $default_dnssec_validation = 'auto'
-      case $::operatingsystemmajrelease {
-        '8': {
-          $necessary_packages = ['bind9']
-        }
-        default: {
-          $necessary_packages = [ 'bind9', 'dnssec-tools' ]
-        }
+      if versioncmp( $::operatingsystemmajrelease, '8' ) >= 0 {
+        $necessary_packages = ['bind9']
+      } else {
+        $necessary_packages = [ 'bind9', 'dnssec-tools' ]
       }
     }
     'RedHat': {


### PR DESCRIPTION
ae6cfc5 already introduced this, but only for debian 8 (jessie). This
patch applies the same thing to debian 9 (stretch) and also all later
versions. The check condition just changed from '==8' to '>=8'.