### PR TITLE
Fix "left match operand must be string" error

### DIFF
--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -16,7 +16,9 @@ define dns::record (
 
   $zone_file_stage = "${data_dir}/db.${zone}.stage"
 
-  if "$ttl" !~ /^[0-9SsMmHhDdWw]+$/ and $ttl != '' {
+  # lint:ignore:only_variable_string
+  if "${ttl}" !~ /^[0-9SsMmHhDdWw]+$/ and $ttl != '' {
+  # lint:endignore:only_variable_string
     fail("Define[dns::record]: TTL ${ttl} must be an integer within 0-2147483647 or explicitly specified time units, e.g. 1h30m.")
   }
 

--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -16,7 +16,7 @@ define dns::record (
 
   $zone_file_stage = "${data_dir}/db.${zone}.stage"
 
-  if $ttl !~ /^[0-9SsMmHhDdWw]+$/ and $ttl != '' {
+  if "$ttl" !~ /^[0-9SsMmHhDdWw]+$/ and $ttl != '' {
     fail("Define[dns::record]: TTL ${ttl} must be an integer within 0-2147483647 or explicitly specified time units, e.g. 1h30m.")
   }
 


### PR DESCRIPTION
I'm unsure if it's a Puppet version thing, but this line was giving me the following error:

Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Left match operand must result in a String value. Got an Integer. at /modules/dns/manifests/record.pp:19:6 at /modules/dns/manifests/record/a.pp:17 on node puppetmaster

Forcing the match operand to a string fixed it for me.
