### PR TITLE
Fix static path in named.conf.default-zones

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -66,9 +66,9 @@ class dns::server::config (
   }
 
   concat::fragment {'default-zones.header':
-    target => $dns::server::params::rfc1912_zones_cfg,
-    order  => '00',
-    source => "puppet:///modules/${module_name}/named.conf.default-zones",
+    target  => $dns::server::params::rfc1912_zones_cfg,
+    order   => '00',
+    content => template('dns/named.conf.default-zones.erb'),
   }
 
   include dns::server::default

--- a/templates/named.conf.default-zones.erb
+++ b/templates/named.conf.default-zones.erb
@@ -2,7 +2,7 @@
 // prime the server with knowledge of the root servers
 zone "." {
 	type hint;
-	file "/etc/bind/db.root";
+	file "<%= @cfg_dir %>/db.root";
 };
 
 // be authoritative for the localhost forward and reverse zones, and for
@@ -10,21 +10,21 @@ zone "." {
 
 zone "localhost" {
 	type master;
-	file "/etc/bind/db.local";
+	file "<%= @cfg_dir %>/db.local";
 };
 
 zone "127.in-addr.arpa" {
 	type master;
-	file "/etc/bind/db.127";
+	file "<%= @cfg_dir %>/db.127";
 };
 
 zone "0.in-addr.arpa" {
 	type master;
-	file "/etc/bind/db.0";
+	file "<%= @cfg_dir %>/db.0";
 };
 
 zone "255.in-addr.arpa" {
 	type master;
-	file "/etc/bind/db.255";
+	file "<%= @cfg_dir %>/db.255";
 };
 


### PR DESCRIPTION
Instead a fixing configuration path, it uses now module variables.
This patch fixes #235 