### PR TITLE
Check zones before using them

### DIFF
--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -19,9 +19,9 @@ class dns::server::params {
       $default_dnssec_enable     = true
       $default_dnssec_validation = 'auto'
       if versioncmp( $::operatingsystemmajrelease, '8' ) >= 0 {
-        $necessary_packages = ['bind9']
+        $necessary_packages = [ 'bind9', 'bind9utils' ]
       } else {
-        $necessary_packages = [ 'bind9', 'dnssec-tools' ]
+        $necessary_packages = [ 'bind9', 'bind9utils', 'dnssec-tools' ]
       }
     }
     'RedHat': {

--- a/spec/classes/dns__server__install_spec.rb
+++ b/spec/classes/dns__server__install_spec.rb
@@ -8,7 +8,7 @@ describe 'dns::server::install', :type => :class do
   context "on a Debian OS with default params" do
     let(:facts) {{ :osfamily => 'Debian' }}
     it { should contain_class('dns::server::params') }
-    ['bind9', 'dnssec-tools'].each do |package|
+    ['bind9', 'bind9utils', 'dnssec-tools'].each do |package|
         it do
           should contain_package(package).with({
             'ensure' => 'latest',
@@ -21,7 +21,7 @@ describe 'dns::server::install', :type => :class do
     let(:facts)  {{ :osfamily        => 'Debian'  }}
     let(:params) {{ :ensure_packages => 'present' }}
     it { should contain_class('dns::server::params') }
-    ['bind9', 'dnssec-tools'].each do |package|
+    ['bind9', 'bind9utils', 'dnssec-tools'].each do |package|
         it do
           should contain_package(package).with({
             'ensure' => 'present',

--- a/spec/classes/server/default_spec.rb
+++ b/spec/classes/server/default_spec.rb
@@ -35,7 +35,7 @@ describe 'dns::server::default' do
       context "requires bind9 and dnssec-tools package" do
         it do
           should contain_file('/etc/default/bind9').with({
-            'require' => ['Package[bind9]', 'Package[dnssec-tools]'],
+            'require' => ['Package[bind9]', 'Package[bind9utils]', 'Package[dnssec-tools]'],
           })
         end
       end

--- a/spec/defines/dns__zone_spec.rb
+++ b/spec/defines/dns__zone_spec.rb
@@ -10,7 +10,7 @@ describe 'dns::zone' do
       it { should raise_error(Puppet::Error, /is not an Array/) }
   end
 
-  describe 'passing an array to $allow_query' do 
+  describe 'passing an array to $allow_query' do
       let(:params) {{ :allow_query => ['192.0.2.0', '2001:db8::/32'] }}
       it { should_not raise_error }
       it {
@@ -70,7 +70,7 @@ describe 'dns::zone' do
       }
       it { should contain_concat('/var/lib/bind/zones/db.test.com.stage') }
       it { should contain_concat__fragment('db.test.com.soa').
-          with_content(/_SERIAL_/)
+          with_content(/00000000001/)
       }
       it { should contain_exec('bump-test.com-serial').
           with_refreshonly('true')
@@ -106,7 +106,7 @@ describe 'dns::zone' do
       it 'should only have a type delegation-only entry' do
           should contain_concat__fragment('named.conf.local.test.com.include').
                      with_content(/zone \"test.com\" \{\s*type delegation-only;\s*\}/)
-      end 
+      end
   end
 
 
@@ -391,4 +391,3 @@ describe 'dns::zone' do
     }
   end
 end
-

--- a/templates/zone_file.erb
+++ b/templates/zone_file.erb
@@ -5,7 +5,7 @@
 $ORIGIN	<%= @zone %>.
 $TTL	<%= @zone_ttl %>
 @	IN	SOA	<%= @soa %>. <%= @soa_email %>. (
-		_SERIAL_		; Serial<%# Be careful at change of number of this line. It is used in zone.pp/Exec[bump-${zone}-serial]. %>
+		00000000001		; Serial<%# Be careful at change of number of this line. It is used in zone.pp/Exec[bump-${zone}-serial]. %>
 		<%= @zone_refresh %>		; Refresh
 		<%= @zone_retry %>		; Retry
 		<%= @zone_expire %>		; Expire


### PR DESCRIPTION
These changes validate all zone files with named-checkzone before putting the new zone file in or restarting BIND. I was having a lot of trouble with making mistakes in my records leading to my DNS servers crashing, this should prevent that.

Tested in CentOS 7 and Ubuntu Xenial as working, though I'm not familiar enough with Rspec to write a test for it unfortunately.