### PR TITLE
Fix dns::server::options declaration

### DIFF
--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -154,7 +154,6 @@
 #    forwarders => [ '8.8.8.8', '8.8.4.4' ],
 #   }
 #
-include dns::server::params
 define dns::server::options (
   $allow_query = [],
   $allow_recursion = [],
@@ -187,6 +186,8 @@ define dns::server::options (
   $zone_notify = undef,
   $extra_options = {},
 ) {
+  include dns::server::params
+
   $valid_check_names = ['fail', 'warn', 'ignore']
   $valid_forward_policy = ['first', 'only']
   $cfg_dir = $::dns::server::params::cfg_dir


### PR DESCRIPTION
The `include` sentence in `dns::server::options` is in the wrong place. Fix it.