### PR TITLE
allow empty forwarders

### DIFF
--- a/templates/zone.erb
+++ b/templates/zone.erb
@@ -28,10 +28,10 @@ zone "<%= @zone %>" {
         };
     <%- end -%>
 <% end -%>
-<% if !@allow_forwarder.empty? and ( @zone_type == 'master' or  @zone_type == 'forward') -%>
+<% if !@zone_forwarders.nil? and ( @zone_type == 'master' or  @zone_type == 'forward' or @zone_type == 'slave') -%>
     forward <%= @forward_policy %>;
     forwarders {
-    <%- @allow_forwarder.each do |ip| -%>
+    <%- @zone_forwarders.each do |ip| -%>
         <%= ip %>;
     <%- end -%>
     };


### PR DESCRIPTION
Hi,

through the explained Issue in that Article 

https://kb.isc.org/docs/aa-00538
Section 3, starting with 
But what happens if you are authoritative for a domain, but have delegated a subdomain to another server? If your nameserver receives a query for a name in the delegated domain, what should it do?

we needed to change zone.erb, to allow us adding "empty" forwarders. Even on slave zones

It would be nice if u would add this.

Thx 
