### PR TITLE
allow for omitting dnssec-enable

### DIFF
--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -62,7 +62,12 @@
 #   Controls whether to enable/disable DNS-SEC support. Boolean.
 #   Default is false on RedHat 5 (for the same reasons as
 #   dnssec_validation above), and true on Debian and on RedHat 6
-#   and above.
+#   and above. For Ubuntu 22.04 and above the default value is undef
+#   (see below).
+#
+#   Setting the value to undef omits this option entirely from the
+#   config. This is because the option had been obsoleted in BIND
+#   9.15.0 and was removed entirely in BIND 9.18.0.
 #
 # [*forward_policy*]
 #   The forwarding policy to use.  Must be `first` or `only`.

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -16,7 +16,18 @@ class dns::server::params {
       $service            = 'bind9'
       $default_file       = '/etc/default/bind9'
       $default_template   = 'default.debian.erb'
-      $default_dnssec_enable     = true
+      case $::facts['os']['name'] {
+        'Ubuntu': {
+          if (versioncmp($::facts['os']['release']['major'], '22.04') >= 0) {
+            $default_dnssec_enable = undef
+          } else {
+            $default_dnssec_enable = true
+          }
+        }
+        default: {
+          $default_dnssec_enable = true
+        }
+      }
       $default_dnssec_validation = 'auto'
       if versioncmp( $::operatingsystemmajrelease, '8' ) >= 0 {
         $necessary_packages = [ 'bind9', 'bind9utils' ]

--- a/templates/named.conf.options.erb
+++ b/templates/named.conf.options.erb
@@ -116,8 +116,10 @@ options {
     // If BIND logs error messages about the root key being expired,
     // you will need to update your keys.  See https://www.isc.org/bind-keys
     //========================================================================
-<% if @dnssec_enable -%>
+<% if @dnssec.nil? or (@dnssec_enable == true) -%>
+<% if @dnssec == true -%>
     dnssec-enable yes;
+<% end -%>
     <%- if @dnssec_validation != 'absent' -%>
     dnssec-validation <%= @dnssec_validation %>;
     <%- end -%>


### PR DESCRIPTION
The setting `dnssec-enable` in `named.conf.options` was deprecated in BIND 9.15 and removed in BIND 9.18. Ubuntu started shipping BIND 9.18 with version 22.04 (Jammy), which produces a config error and fails to start if the setting is present.

This PR allows for omitting `dnssec-enable` from `named.conf.options` by setting `dns::server::options::dnssec_enable` to `undef`, and also makes `undef` the default value for Ubuntu 22.04 and above.