### PR TITLE
Improve root hints file handling

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -6,11 +6,12 @@ class dns::server (
   $necessary_packages = $dns::server::params::necessary_packages,
   $ensure_packages    = $dns::server::params::ensure_packages,
 
-  $cfg_dir  = $dns::server::params::cfg_dir,
-  $cfg_file = $dns::server::params::cfg_file,
-  $data_dir = $dns::server::params::data_dir,
-  $owner    = $dns::server::params::owner,
-  $group    = $dns::server::params::group,
+  $cfg_dir   = $dns::server::params::cfg_dir,
+  $cfg_file  = $dns::server::params::cfg_file,
+  $data_dir  = $dns::server::params::data_dir,
+  $root_hint = $dns::server::params::root_hint,
+  $owner     = $dns::server::params::owner,
+  $group     = $dns::server::params::group,
 
   $enable_default_zones = true,
 ) inherits dns::server::params {
@@ -21,6 +22,7 @@ class dns::server (
     cfg_dir              => $cfg_dir,
     cfg_file             => $cfg_file,
     data_dir             => $data_dir,
+    root_hint            => $root_hint,
     owner                => $owner,
     group                => $group,
     enable_default_zones => $enable_default_zones,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -4,6 +4,7 @@ class dns::server::config (
   $cfg_dir              = $dns::server::params::cfg_dir,
   $cfg_file             = $dns::server::params::cfg_file,
   $data_dir             = $dns::server::params::data_dir,
+  $root_hint            = $dns::server::params::root_hint,
   $owner                = $dns::server::params::owner,
   $group                = $dns::server::params::group,
   $enable_default_zones = true,

--- a/templates/named.conf.default-zones.erb
+++ b/templates/named.conf.default-zones.erb
@@ -2,7 +2,7 @@
 // prime the server with knowledge of the root servers
 zone "." {
 	type hint;
-	file "<%= @cfg_dir %>/db.root";
+	file "<%= @root_hint %>";
 };
 
 // be authoritative for the localhost forward and reverse zones, and for


### PR DESCRIPTION
The root zone should use the hints file defined in `params.pp` by default. It should also be possible to override the file, since Debian-based systems have started to ship the root hints as `/usr/share/dns/root.hints` instead of `/etc/bind/db.root`.